### PR TITLE
Update and complete benchmarks

### DIFF
--- a/comparison/pom.xml
+++ b/comparison/pom.xml
@@ -19,17 +19,17 @@
         <dependency>
             <groupId>org.jwat</groupId>
             <artifactId>jwat-warc</artifactId>
-            <version>1.1.0</version>
+            <version>1.1.1</version>
         </dependency>
         <dependency>
             <groupId>org.netpreserve.commons</groupId>
             <artifactId>webarchive-commons</artifactId>
-            <version>1.1.8</version>
+            <version>1.1.9</version>
         </dependency>
         <dependency>
             <groupId>org.netpreserve</groupId>
             <artifactId>jwarc</artifactId>
-            <version>0.1.0</version>
+            <version>0.8.4-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/comparison/src/Bench.java
+++ b/comparison/src/Bench.java
@@ -14,75 +14,128 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
+import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.function.Function;
 import java.util.zip.GZIPInputStream;
 
 public class Bench {
-    public static void main(String[] args) throws IOException {
+
+    @FunctionalInterface
+    public interface ThrowingFunction<R, T, E extends Exception> {
+        R apply(T t) throws E;
+    }
+
+    private static void bench(String name, ThrowingFunction<String, String, IOException> func, String filename) {
+        long start = System.currentTimeMillis();
+        try {
+            String res = func.apply(filename);
+            System.out.println(name + " " + res + " in " + (System.currentTimeMillis() - start) + "ms");
+        } catch(IOException e) {
+            System.out.println(name + " failed after " + (System.currentTimeMillis() - start) + "ms throwing " + e);
+        }
+    }
+
+    private static String gzip(String filename, int bufferSize) throws IOException {
+        byte[] buf = new byte[bufferSize];
+        try (GZIPInputStream gzis = new GZIPInputStream(new FileInputStream(new File(filename)), bufferSize)) {
+            while (true) {
+                int n = gzis.read(buf);
+                if (n < 0) {
+                    break;
+                }
+            }
+        }
+        return "";
+    }
+
+    private static String gzip8k(String filename) throws IOException {
+        return gzip(filename, 8192);
+    }
+
+    private static String gzip64k(String filename) throws IOException {
+        return gzip(filename, 65536);
+    }
+
+    private static String webarchiveCommons(String filename) throws IOException {
+        long count = 0;
+        try (ArchiveReader reader = WARCReaderFactory.get(new File(filename))) {
+            for (ArchiveRecord record : reader) {
+                count++;
+            }
+        }
+        return Long.toString(count);
+    }
+
+    private static String webarchiveCommonsNoDigest(String filename) throws IOException {
+        long count = 0;
+        try (ArchiveReader reader = WARCReaderFactory.get(new File(filename))) {
+            reader.setDigest(false);
+            for (ArchiveRecord record : reader) {
+                count++;
+            }
+        }
+        return Long.toString(count);
+    }
+
+    private static String jwat(String filename) throws IOException {
+        long count = 0;
+        try (WarcReader reader = WarcReaderFactory.getReader(new FileInputStream(filename))) {
+            for (WarcRecord record : reader) {
+                count++;
+            }
+        }
+        return Long.toString(count);
+    }
+
+    private static String jwatBuff(String filename) throws IOException {
+        long count = 0;
+        try (WarcReader reader = WarcReaderFactory.getReader(new FileInputStream(filename), 8192)) {
+            for (WarcRecord record : reader) {
+                count++;
+            }
+        }
+        return Long.toString(count);
+    }
+
+    private static String jwarc(String filename) throws IOException {
+        long count = 0;
+        try (org.netpreserve.jwarc.WarcReader reader = new org.netpreserve.jwarc.WarcReader(FileChannel.open(Paths.get(filename)))) {
+            for (org.netpreserve.jwarc.WarcRecord record : reader) {
+                count++;
+            }
+        }
+        return Long.toString(count);
+    }
+
+    public static void main(String[] args) {
         String filename = args[0];
+        System.out.println("Benchmarking " + filename);
 
-        while (true) {
+        int iterations = 3;
+
+        try {
+            Thread.sleep(1000); // sleep a short time to be able to attach a profiler
+        } catch(Exception e) {
+        }
+
+        for (int i = 1; i <= iterations; i++) {
+            System.out.println("iteration " + i);
+
             if (filename.endsWith(".gz")) {
-                long start = System.currentTimeMillis();
-                long count = 0;
-                byte[] buf = new byte[8192];
-                try (GZIPInputStream gzis = new GZIPInputStream(new FileInputStream(new File(filename)), 8192)) {
-                    while (true) {
-                        int n = gzis.read(buf);
-                        if (n < 0) {
-                            break;
-                        }
-                    }
-                }
-                System.out.println("gzipinpustream in " + (System.currentTimeMillis() - start) + "ms");
+                bench("gzipinputstream (buffer 8kB)", Bench::gzip8k, filename);
+                bench("gzipinputstream (buffer 64kB)", Bench::gzip64k, filename);
             }
 
-            {
-                long start = System.currentTimeMillis();
-                long count = 0;
-                try (ArchiveReader reader = WARCReaderFactory.get(new File(filename))) {
-                    for (ArchiveRecord record : reader) {
-                        count++;
-                    }
-                }
-                System.out.println("webarchive-commons " + count + " in " + (System.currentTimeMillis() - start) + "ms");
-            }
+            bench("webarchive-commons", Bench::webarchiveCommons, filename);
+            bench("webarchive-commons (no digest check)", Bench::webarchiveCommonsNoDigest, filename);
 
-//            {
-//                long start = System.currentTimeMillis();
-//                long count = 0;
-//                try (WarcReader reader = WarcReaderFactory.getReader(new FileInputStream(filename))) {
-//                    for (WarcRecord record : reader) {
-//                        count++;
-//                    }
-//                }
-//                System.out.println("jwat " + count + " in " + (System.currentTimeMillis() - start) + "ms");
-//            }
+            //bench("jwat", Bench::jwat, filename);
+            bench("jwat buff", Bench::jwatBuff, filename);
 
-            {
-                long start = System.currentTimeMillis();
-                long count = 0;
-                try (WarcReader reader = WarcReaderFactory.getReader(new FileInputStream(filename), 8192)) {
-                    for (WarcRecord record : reader) {
-                        count++;
-                    }
-                }
-                System.out.println("jwat buff " + count + " in " + (System.currentTimeMillis() - start) + "ms");
-            }
-
-            {
-                long start = System.currentTimeMillis();
-                long count = 0;
-                try (org.netpreserve.jwarc.WarcReader reader = new org.netpreserve.jwarc.WarcReader(FileChannel.open(Paths.get(filename)))) {
-                    for (org.netpreserve.jwarc.WarcRecord record : reader) {
-                        count++;
-                    }
-                }
-                System.out.println("jwarc " + count + " in " + (System.currentTimeMillis() - start) + "ms");
-            }
+            bench("jwarc", Bench::jwarc, filename);
 
             System.out.println("");
-
         }
     }
 }


### PR DESCRIPTION
Just a couple of updates of the comparison/benchmarking tool, also to discuss possible further performance improvements

- upgrade to most recent versions of compared libs/tools
- for easier profiling:
  - wrap profiled tools and parameters into methods to have a separate stack
  - sleep 1 sec. at start to allow to attach a profiler
- catch exceptions and keep going to benchmark remaining tools
- webarchive-commons: add variant with disabled signature check
- gzip: add variant with increased buffer size (64 kiB)

Shortly about the results (on a [gzipped WARC file](https://commoncrawl.s3.amazonaws.com/crawl-data/CC-MAIN-2019-51/segments/1575540500637.40/warc/CC-MAIN-20191207160050-20191207184050-00031.warc.gz)):
- a larger buffer size (8 -> 64 kiB) seems to speed up gzip, could be worth to try this also for jwarc
- webarchive-commons is faster by 36% if no digest is calculated while reading the WARC file

Output:
```
Benchmarking CC-MAIN-20191207160050-20191207184050-00031.warc.gz
iteration 1
gzipinputstream (buffer 8kB)  in 12253ms
gzipinputstream (buffer 64kB)  in 10904ms
webarchive-commons 133945 in 40756ms
webarchive-commons (no digest check) 133945 in 24176ms
jwat buff 133945 in 21584ms
jwarc 133945 in 14623ms

iteration 2
gzipinputstream (buffer 8kB)  in 12583ms
gzipinputstream (buffer 64kB)  in 11482ms
webarchive-commons 133945 in 43104ms
webarchive-commons (no digest check) 133945 in 23460ms
jwat buff 133945 in 20800ms
jwarc 133945 in 14962ms

iteration 3
gzipinputstream (buffer 8kB)  in 12953ms
gzipinputstream (buffer 64kB)  in 12496ms
webarchive-commons 133945 in 44103ms
webarchive-commons (no digest check) 133945 in 24895ms
jwat buff 133945 in 19573ms
jwarc 133945 in 13978ms
```

Profile using [async-profiler](/jvm-profiling-tools/async-profiler) (interactive SVG [bench.2020-01-17-17-57.async-prof.svg.gz](https://github.com/iipc/jwarc/files/4085396/bench.2020-01-17-17-57.async-prof.svg.gz)):
![bench 2020-01-17-17-57 async-prof](https://user-images.githubusercontent.com/1630582/72714403-f28d2880-3b6e-11ea-8c83-a4acb8789168.png)



