### PR TITLE
Support writing of gzipped WARC files

### DIFF
--- a/src/org/netpreserve/jwarc/GunzipChannel.java
+++ b/src/org/netpreserve/jwarc/GunzipChannel.java
@@ -20,8 +20,8 @@ class GunzipChannel implements ReadableByteChannel {
     private static final int FEXTRA = 4;
     private static final int FNAME = 8;
     private static final int FCOMMENT = 16;
-    private static final int CM_DEFLATE = 8;
-    private static final short GZIP_MAGIC = (short) 0x8b1f;
+    private static final int CM_DEFLATE = GzipChannel.CM_DEFLATE;
+    private static final short GZIP_MAGIC = GzipChannel.GZIP_MAGIC;
 
     private final ReadableByteChannel channel;
     private final ByteBuffer buffer;

--- a/src/org/netpreserve/jwarc/GzipChannel.java
+++ b/src/org/netpreserve/jwarc/GzipChannel.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2020 National Library of Australia and the jwarc contributors
+ */
+
+package org.netpreserve.jwarc;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.WritableByteChannel;
+import java.util.zip.CRC32;
+import java.util.zip.Deflater;
+
+/**
+ * A channel that compresses the input using gzip before writing
+ * 
+ * GzipChannel allows to write the data as sequence of independently compressed
+ * gzip "members" in order to follow the "record-at-time compression"
+ * recommendation of the <a href=
+ * "https://iipc.github.io/warc-specifications/specifications/warc-format/warc-1.1/#record-at-time-compression">WARC
+ * specification</a>, see {@link #finish()}.
+ * 
+ */
+class GzipChannel implements WritableByteChannel {
+
+    static final short GZIP_MAGIC = (short) 0x8b1f;
+    static final int CM_DEFLATE = Deflater.DEFLATED;
+
+    /** Default gzip header, 10 bytes long */
+    private static final byte[] GZIP_HEADER_ = new byte[] { //
+            (byte) GZIP_MAGIC, //
+            (byte) (GZIP_MAGIC >> 8), //
+            Deflater.DEFLATED, //
+            0, 0, 0, 0, 0, 0, 0 };
+    private static final ByteBuffer GZIP_HEADER = ByteBuffer.wrap(GZIP_HEADER_);
+
+    private boolean headerWritten = false;
+    private boolean finished = false;
+    private boolean dataWritten = false;
+    private final WritableByteChannel channel;
+    private final Deflater deflater = new Deflater(Deflater.BEST_COMPRESSION, true);
+    private final ByteBuffer buffer;
+    private final CRC32 crc = new CRC32();
+
+    public GzipChannel(WritableByteChannel channel) throws IOException {
+        this(channel, ByteBuffer.allocate(8192));
+    }
+
+    public GzipChannel(WritableByteChannel channel, ByteBuffer buffer) throws IOException, IllegalArgumentException {
+        this.channel = channel;
+        this.buffer = buffer;
+        if (!buffer.hasArray()) {
+            throw new IllegalArgumentException("ByteBuffer must be array-backed and writable");
+        }
+        this.buffer.order(ByteOrder.LITTLE_ENDIAN);
+    }
+
+    private int checkStatus(boolean finish) throws IOException {
+        int cwritten = 0;
+        if ((finish && !dataWritten) || (!finish && !headerWritten)) {
+            cwritten += writeHeader();
+            dataWritten = true;
+            finished = false;
+        }
+        return cwritten;
+    }
+
+    private int writeHeader() throws IOException {
+        int n = channel.write(GZIP_HEADER);
+        GZIP_HEADER.rewind();
+        headerWritten = true;
+        return n;
+    }
+
+    /**
+     * Finish the current gzip member (independently compressed and decompressable).
+     * The next call of {@link #write(ByteBuffer)} will automatically start the a
+     * new gzip member.
+     * 
+     * @return The number of bytes written when finishing the current gzip member,
+     *         zero if current member is already finished
+     */
+    public int finish() throws IOException {
+        if (finished) {
+            return 0;
+        }
+
+        int cwritten = checkStatus(true);
+
+        deflater.finish();
+
+        int clen;
+        while ((clen = deflater.deflate(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.remaining(),
+                Deflater.FULL_FLUSH)) > 0) {
+            buffer.position(buffer.position() + clen);
+            buffer.flip();
+            cwritten += channel.write(buffer);
+            buffer.compact();
+        }
+
+        // write CRC and uncompressed data length
+        buffer.putInt((int) crc.getValue());
+        buffer.putInt((int) deflater.getBytesRead());
+        buffer.flip();
+        cwritten += channel.write(buffer);
+        buffer.compact();
+
+        deflater.reset();
+        crc.reset();
+        finished = true;
+        headerWritten = false;
+
+        return cwritten;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return channel.isOpen();
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (!finished) {
+            // finish current gzip member if not done explicitly by calling finish()
+            finish();
+        }
+        channel.close();
+    }
+
+    @Override
+    public int write(ByteBuffer src) throws IOException {
+        byte[] srcBytes;
+        int off = src.position();
+        int len = src.remaining();
+        if (len == 0) {
+            // nothing to write
+            return 0;
+        } else if ( src.hasArray() ) {
+            srcBytes = src.array();
+            src.position(len);
+            src.limit(len);
+        } else {
+            off = 0;
+            srcBytes = new byte[len];
+            src.get(srcBytes);
+        }
+
+        crc.update(srcBytes, off, len);
+        deflater.setInput(srcBytes, off, len);
+
+        int cwritten = checkStatus(false);
+        int clen;
+        while (!deflater.needsInput()) {
+            clen = deflater.deflate(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.remaining(),
+                    Deflater.NO_FLUSH);
+            if (clen > 0) {
+                buffer.position(buffer.position() + clen);
+                buffer.flip();
+                cwritten += channel.write(buffer);
+                buffer.compact();
+            }
+        }
+
+        return cwritten;
+    }
+
+}

--- a/test/org/netpreserve/jwarc/GzipChannelTest.java
+++ b/test/org/netpreserve/jwarc/GzipChannelTest.java
@@ -14,7 +14,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.Channels;
-import java.nio.channels.WritableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.zip.GZIPInputStream;
@@ -104,7 +103,6 @@ public class GzipChannelTest {
         assertEquals(text, new String(inBytes, 0, n, StandardCharsets.US_ASCII));
 
         // read second member
-        assertTrue(gzis.available() > 0);
         n = gzis.read(inBytes);
         assertEquals(n, textBytes.length);
         assertEquals(text, new String(inBytes, 0, n, StandardCharsets.US_ASCII));

--- a/test/org/netpreserve/jwarc/GzipChannelTest.java
+++ b/test/org/netpreserve/jwarc/GzipChannelTest.java
@@ -1,0 +1,119 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2020 National Library of Australia and the jwarc contributors
+ */
+
+package org.netpreserve.jwarc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.zip.GZIPInputStream;
+
+import org.junit.Test;
+
+public class GzipChannelTest {
+
+    protected String text = "Hello world";
+    protected byte[] textBytes = text.getBytes(StandardCharsets.US_ASCII);
+
+    private void checkGzip(byte[] gzipped) {
+        // did we get valid gzipped data?
+        short magic = ByteBuffer.wrap(gzipped).order(ByteOrder.LITTLE_ENDIAN).getShort();
+        assertEquals(magic, GzipChannel.GZIP_MAGIC);
+        assertTrue(gzipped.length >= 20);
+    }
+
+    @Test
+    public void test() throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        GzipChannel channel = new GzipChannel(Channels.newChannel(baos));
+        channel.write(ByteBuffer.wrap(textBytes));
+        channel.close();
+        byte[] gzipped = baos.toByteArray();
+
+        checkGzip(gzipped);
+
+        GZIPInputStream gzis = new GZIPInputStream(new ByteArrayInputStream(gzipped));
+        byte[] inBytes = new byte[8192];
+        int n = gzis.read(inBytes);
+
+        assertEquals(n, textBytes.length);
+        assertEquals(text, new String(inBytes, 0, n, StandardCharsets.US_ASCII));
+    }
+
+    /**
+     * Test that zero content (empty string, zero bytes input) is written as valid
+     * gzip data, otherwise uncompressing will cause an error.
+     */
+    @Test
+    public void testEmpty() throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        GzipChannel channel = new GzipChannel(Channels.newChannel(baos));
+        channel.write(ByteBuffer.allocate(0));
+        channel.finish();
+        channel.close();
+        byte[] gzipped = baos.toByteArray();
+
+        checkGzip(gzipped);
+
+        byte[] inBytes = new byte[8192];
+        int n = (new GZIPInputStream(new ByteArrayInputStream(gzipped))).read(inBytes);
+        assertTrue(n <= 0);
+
+        // test without calling write() and finish()
+        baos = new ByteArrayOutputStream();
+        channel = new GzipChannel(Channels.newChannel(baos));
+        channel.close();
+        gzipped = baos.toByteArray();
+
+        checkGzip(gzipped);
+
+        n = (new GZIPInputStream(new ByteArrayInputStream(gzipped))).read(inBytes);
+        assertTrue(n <= 0);
+    }
+
+    @Test
+    public void testMultiMember() throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        GzipChannel channel = new GzipChannel(Channels.newChannel(baos));
+        int posSecond = 0;
+        posSecond += channel.write(ByteBuffer.wrap(textBytes));
+        posSecond += channel.finish(); // finish first member
+        channel.write(ByteBuffer.wrap(textBytes));
+        channel.close();
+        byte[] gzipped = baos.toByteArray();
+
+        checkGzip(gzipped);
+        checkGzip(Arrays.copyOfRange(gzipped, posSecond, gzipped.length));
+
+        GZIPInputStream gzis = new GZIPInputStream(new ByteArrayInputStream(gzipped));
+        byte[] inBytes = new byte[8192];
+        int n = gzis.read(inBytes);
+
+        assertEquals(n, textBytes.length);
+        assertEquals(text, new String(inBytes, 0, n, StandardCharsets.US_ASCII));
+
+        // read second member
+        assertTrue(gzis.available() > 0);
+        n = gzis.read(inBytes);
+        assertEquals(n, textBytes.length);
+        assertEquals(text, new String(inBytes, 0, n, StandardCharsets.US_ASCII));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBufferNoArray() throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        GzipChannel channel = new GzipChannel(Channels.newChannel(baos), ByteBuffer.allocate(1024).asReadOnlyBuffer());
+        channel.close();
+    }
+}

--- a/test/org/netpreserve/jwarc/apitests/WarcWriterTest.java
+++ b/test/org/netpreserve/jwarc/apitests/WarcWriterTest.java
@@ -1,0 +1,80 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2020 National Library of Australia and the jwarc contributors
+ */
+
+package org.netpreserve.jwarc.apitests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.zip.GZIPInputStream;
+
+import org.junit.Test;
+import org.netpreserve.jwarc.HttpResponse;
+import org.netpreserve.jwarc.MediaType;
+import org.netpreserve.jwarc.WarcCompression;
+import org.netpreserve.jwarc.WarcReader;
+import org.netpreserve.jwarc.WarcRecord;
+import org.netpreserve.jwarc.WarcResponse;
+import org.netpreserve.jwarc.WarcWriter;
+
+public class WarcWriterTest {
+
+    @Test
+    public void gzippedWarc() throws IOException, URISyntaxException {
+        // write gzipped WARC file to memory
+        String body = "<html><head/><body>Test</body></html>";
+        byte[] bodyBytes = body.getBytes(StandardCharsets.US_ASCII);
+        HttpResponse response = new HttpResponse.Builder(200, "OK").addHeader("Server", "test")
+                .body(MediaType.HTML, bodyBytes).build();
+        WarcResponse record = new WarcResponse.Builder(URI.create("https://example.org/")).body(response).build();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        WritableByteChannel output = Channels.newChannel(baos);
+        WarcWriter writer = new WarcWriter(output, WarcCompression.GZIP);
+        writer.write(record);
+        writer.close();
+        byte[] warcBytes = baos.toByteArray();
+
+        // did we get a gzipped WARC?
+        assertEquals(warcBytes[0], (byte) 0x1f);
+        assertEquals(warcBytes[1], (byte) 0x8b);
+
+        // uncompress and check whether body is contained
+        ByteArrayInputStream bais = new ByteArrayInputStream(warcBytes);
+        GZIPInputStream gzin = new GZIPInputStream(bais);
+        byte[] warcb = new byte[8192];
+        int n = gzin.read(warcb);
+        String warc = new String(warcb, 0, n, StandardCharsets.US_ASCII);
+        assertTrue(warc.contains(body));
+
+        // read gzipped WARC using WarcReader
+        bais.reset();
+        WarcReader reader = new WarcReader(bais);
+        Optional<WarcRecord> res = reader.next();
+        reader.close();
+        assertTrue(res.isPresent());
+        WarcRecord rec = res.get();
+        assertTrue(rec instanceof WarcResponse);
+        WarcResponse resp = (WarcResponse) rec;
+        ByteBuffer buf = ByteBuffer.allocate(64);
+        n = resp.http().body().read(buf);
+        buf.flip();
+        byte[] b = new byte[n];
+        buf.get(b);
+        assertEquals(body, new String(b, StandardCharsets.US_ASCII));
+        assertTrue(resp.http().headers().map().containsKey("Server"));
+        assertEquals("test", resp.http().headers().map().get("Server").get(0));
+    }
+
+}


### PR DESCRIPTION
- adds GzipChannel to write data using gzip compression (optionally multi-member gzips)
- implements writing per-record gzip-compressed WARCs in WarcWriter