### PR TITLE
WarcReader/GunzipChannel to check ByteBuffer in constructor, #21

### DIFF
--- a/src/org/netpreserve/jwarc/GunzipChannel.java
+++ b/src/org/netpreserve/jwarc/GunzipChannel.java
@@ -30,9 +30,12 @@ class GunzipChannel implements ReadableByteChannel {
     private boolean seenHeader;
     private CRC32 crc; //= new CRC32();
 
-    public GunzipChannel(ReadableByteChannel channel, ByteBuffer buffer) {
+    public GunzipChannel(ReadableByteChannel channel, ByteBuffer buffer) throws IllegalArgumentException {
         this.channel = channel;
         this.buffer = buffer;
+        if (!buffer.hasArray()) {
+            throw new IllegalArgumentException("ByteBuffer must be array-backed and writable");
+        }
         buffer.order(ByteOrder.LITTLE_ENDIAN);
     }
 


### PR DESCRIPTION
- fix detection of gzip magic in WarcReader if buffer has byte order little endian
- throw IllegalArgumentException if buffer is read-only or is not backed by an array
- document that buffer must be in read state
- add unit tests for buffer byte order, read-only buffers and a pre-populated buffer