### PR TITLE
Message parsers to log context of parse errors

### DIFF
--- a/src/org/netpreserve/jwarc/ChunkedBody.java
+++ b/src/org/netpreserve/jwarc/ChunkedBody.java
@@ -48,9 +48,11 @@ class ChunkedBody extends MessageBody {
                 }
 
                 // refill
+                ByteBuffer copy = buffer.duplicate();
                 buffer.compact();
                 if (channel.read(buffer) < 0) {
-                    throw new EOFException("EOF reached before end of chunked encoding");
+                    throw new EOFException("EOF reached before end of chunked encoding: "
+                            + getErrorContext(copy, (int) copy.position(), 40));
                 }
                 buffer.flip();
             }
@@ -72,7 +74,7 @@ class ChunkedBody extends MessageBody {
     }
 
     
-// line 115 "ChunkedBody.rl"
+// line 117 "ChunkedBody.rl"
 
 
     private int cs = chunked_start;
@@ -82,7 +84,7 @@ class ChunkedBody extends MessageBody {
         int p = buffer.position();
         int pe = buffer.limit();
         
-// line 86 "ChunkedBody.java"
+// line 88 "ChunkedBody.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -163,18 +165,18 @@ case 1:
 			switch ( _chunked_actions[_acts++] )
 			{
 	case 0:
-// line 76 "ChunkedBody.rl"
+// line 78 "ChunkedBody.rl"
 	{ tmp = tmp * 16 + Character.digit(buffer.get(p), 16); }
 	break;
 	case 1:
-// line 77 "ChunkedBody.rl"
+// line 79 "ChunkedBody.rl"
 	{ if (tmp != 0) { chunkLength = tmp; tmp = 0; { p += 1; _goto_targ = 5; if (true)  continue _goto;} } }
 	break;
 	case 2:
-// line 78 "ChunkedBody.rl"
+// line 80 "ChunkedBody.rl"
 	{ chunkLength = 0; }
 	break;
-// line 178 "ChunkedBody.java"
+// line 180 "ChunkedBody.java"
 			}
 		}
 	}
@@ -194,15 +196,16 @@ case 5:
 	break; }
 	}
 
-// line 124 "ChunkedBody.rl"
+// line 126 "ChunkedBody.rl"
         buffer.position(p);
         if (cs == chunked_error) {
-            throw new ParsingException("chunked encoding (p=" + p + ")");
+            throw new ParsingException("chunked encoding at position " + p + ": "
+                    + getErrorContext(buffer, (int) p, 40));
         }
     }
 
     
-// line 206 "ChunkedBody.java"
+// line 209 "ChunkedBody.java"
 private static byte[] init__chunked_actions_0()
 {
 	return new byte [] {
@@ -331,5 +334,5 @@ static final int chunked_error = 0;
 static final int chunked_en_chunks = 1;
 
 
-// line 131 "ChunkedBody.rl"
+// line 134 "ChunkedBody.rl"
 }

--- a/src/org/netpreserve/jwarc/HttpParser.java
+++ b/src/org/netpreserve/jwarc/HttpParser.java
@@ -18,7 +18,7 @@ import java.util.*;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
-public class HttpParser {
+public class HttpParser extends MessageParser {
     private int cs;
     private long position;
     private boolean finished;
@@ -283,6 +283,7 @@ case 5:
     void parse(ReadableByteChannel channel, ByteBuffer buffer, WritableByteChannel copyTo) throws IOException {
         while (true) {
             ByteBuffer copy = buffer.duplicate();
+            long buffOffset = buffer.position() - position;
             parse(buffer);
             if (copyTo != null) {
                 copy.limit(buffer.position());
@@ -292,7 +293,8 @@ case 5:
                 break;
             }
             if (isError()) {
-                throw new ParsingException("invalid HTTP message at byte position " + position);
+                throw new ParsingException("invalid HTTP message at byte position " + position + ": "
+                        + getErrorContext(buffer.duplicate(), (int) (buffOffset + position), 40));
             }
             buffer.compact();
             int n = channel.read(buffer);
@@ -309,7 +311,7 @@ case 5:
     }
 
     
-// line 313 "HttpParser.java"
+// line 315 "HttpParser.java"
 private static byte[] init__http_actions_0()
 {
 	return new byte [] {
@@ -475,5 +477,5 @@ static final int http_en_http_request = 25;
 static final int http_en_http_response = 1;
 
 
-// line 220 "HttpParser.rl"
+// line 222 "HttpParser.rl"
 }

--- a/src/org/netpreserve/jwarc/HttpParser.rl
+++ b/src/org/netpreserve/jwarc/HttpParser.rl
@@ -94,7 +94,7 @@ import java.util.*;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
-public class HttpParser {
+public class HttpParser extends MessageParser {
     private int cs;
     private long position;
     private boolean finished;
@@ -191,6 +191,7 @@ public class HttpParser {
     void parse(ReadableByteChannel channel, ByteBuffer buffer, WritableByteChannel copyTo) throws IOException {
         while (true) {
             ByteBuffer copy = buffer.duplicate();
+            long buffOffset = buffer.position() - position;
             parse(buffer);
             if (copyTo != null) {
                 copy.limit(buffer.position());
@@ -200,7 +201,8 @@ public class HttpParser {
                 break;
             }
             if (isError()) {
-                throw new ParsingException("invalid HTTP message at byte position " + position);
+                throw new ParsingException("invalid HTTP message at byte position " + position + ": "
+                        + getErrorContext(buffer.duplicate(), (int) (buffOffset + position), 40));
             }
             buffer.compact();
             int n = channel.read(buffer);

--- a/src/org/netpreserve/jwarc/MessageBody.java
+++ b/src/org/netpreserve/jwarc/MessageBody.java
@@ -7,7 +7,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 
-public abstract class MessageBody implements ReadableByteChannel {
+public abstract class MessageBody extends MessageParser implements ReadableByteChannel {
     MessageBody() {
     }
 

--- a/src/org/netpreserve/jwarc/MessageParser.java
+++ b/src/org/netpreserve/jwarc/MessageParser.java
@@ -1,0 +1,56 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2020 National Library of Australia and the jwarc contributors
+ */
+
+package org.netpreserve.jwarc;
+
+import java.nio.ByteBuffer;
+
+public class MessageParser {
+
+    protected static String getErrorContext(ByteBuffer buffer, int position, int length) {
+        StringBuilder context = new StringBuilder();
+
+        int start = position - length;
+        if (start < 0) {
+            start = 0;
+        } else {
+            context.append("...");
+        }
+
+        ByteBuffer copy = buffer.duplicate();
+        copy.position(start);
+
+        int end = position + length;
+        if (end < buffer.limit()) {
+            copy.limit(end);
+        }
+
+        while (true) {
+            if (copy.position() == position) {
+                context.append("<-- HERE -->");
+            }
+            if (!copy.hasRemaining()) break;
+            int c = (int) copy.get();
+            if (c < 0x7f && c >= 0x20) {
+                context.append((char) c);
+            } else if (c == 0x09) {
+                context.append("\\t");
+            } else if (c == 0x0a) {
+                context.append("\\n");
+            } else if (c == 0x0d) {
+                context.append("\\r");
+            } else {
+                context.append(String.format("\\x%02x", c));
+            }
+        }
+
+        if (copy.position() < buffer.limit()) {
+            context.append("...");
+        }
+
+        return context.toString();
+    }
+
+}

--- a/src/org/netpreserve/jwarc/WarcParser.java
+++ b/src/org/netpreserve/jwarc/WarcParser.java
@@ -29,7 +29,7 @@ import static java.nio.charset.StandardCharsets.US_ASCII;
  * Unless you're doing something advanced (like non-blocking IO) you should use the higher-level {@link WarcReader}
  * class instead.
  */
-public class WarcParser {
+public class WarcParser extends MessageParser {
     private int entryState;
     private int cs;
     private long position;
@@ -299,7 +299,8 @@ case 5:
                 return true;
             }
             if (isError()) {
-                throw new ParsingException("invalid WARC record at position " + position);
+                throw new ParsingException("invalid WARC record at position " + position + ": "
+                        + getErrorContext(buffer, (int) position, 40));
             }
             buffer.compact();
             int n = channel.read(buffer);
@@ -339,7 +340,7 @@ case 5:
     }
 
     
-// line 343 "WarcParser.java"
+// line 344 "WarcParser.java"
 private static byte[] init__warc_actions_0()
 {
 	return new byte [] {
@@ -538,5 +539,5 @@ static final int warc_en_warc_fields = 66;
 static final int warc_en_any_header = 1;
 
 
-// line 259 "WarcParser.rl"
+// line 260 "WarcParser.rl"
 }

--- a/src/org/netpreserve/jwarc/WarcParser.rl
+++ b/src/org/netpreserve/jwarc/WarcParser.rl
@@ -150,7 +150,7 @@ any_header := (arc_header | warc_header) @{ fbreak; };
  * Unless you're doing something advanced (like non-blocking IO) you should use the higher-level {@link WarcReader}
  * class instead.
  */
-public class WarcParser {
+public class WarcParser extends MessageParser {
     private int entryState;
     private int cs;
     private long position;
@@ -216,7 +216,8 @@ public class WarcParser {
                 return true;
             }
             if (isError()) {
-                throw new ParsingException("invalid WARC record at position " + position);
+                throw new ParsingException("invalid WARC record at position " + position + ": "
+                        + getErrorContext(buffer, (int) position, 40));
             }
             buffer.compact();
             int n = channel.read(buffer);


### PR DESCRIPTION
- make HttpParser, ChunkedBody and HttpParser log context before and after the current position as part of the message of a ParseException or EOFException
- 40 bytes of context are logged (less if not buffered)
- unprintable characters including non-ASCII characters are shown escaped (`\x00`)

The method used for putting together the context is places in a new class MessageParser. Of course, it could be placed in a utils class.