### PR TITLE
Fix extraction of payload without HTTP Content-Length header, fixes #36

### DIFF
--- a/src/org/netpreserve/jwarc/HttpResponse.java
+++ b/src/org/netpreserve/jwarc/HttpResponse.java
@@ -73,7 +73,10 @@ public class HttpResponse extends HttpMessage {
         if (headers.sole("Transfer-Encoding").orElse("").equalsIgnoreCase("chunked")) {
             body = new ChunkedBody(channel, buffer);
         } else {
-            if (channel instanceof LengthedBody) {
+            if (channel instanceof LengthedBody.LengthedReadableByteChannel) {
+                LengthedBody.LengthedReadableByteChannel lengthed = (LengthedBody.LengthedReadableByteChannel) channel;
+                contentLength = lengthed.size() - lengthed.position() + buffer.remaining();
+            } else if (channel instanceof LengthedBody) {
                 LengthedBody lengthed = (LengthedBody) channel;
                 contentLength = lengthed.size() - lengthed.position() + buffer.remaining();
             } else {

--- a/src/org/netpreserve/jwarc/LengthedBody.java
+++ b/src/org/netpreserve/jwarc/LengthedBody.java
@@ -125,8 +125,13 @@ public class LengthedBody extends MessageBody {
         }
     }
 
+    public interface LengthedReadableByteChannel extends ReadableByteChannel {
+        public long position();
+        public long size();
+    }
+
     ReadableByteChannel discardPushbackOnRead() {
-        return new ReadableByteChannel() {
+        return new LengthedReadableByteChannel() {
             @Override
             public int read(ByteBuffer byteBuffer) throws IOException {
                 discardPushback();
@@ -141,6 +146,16 @@ public class LengthedBody extends MessageBody {
             @Override
             public void close() throws IOException {
                 LengthedBody.this.close();
+            }
+
+            @Override
+            public long position() {
+                return LengthedBody.this.position;
+            }
+
+            @Override
+            public long size() {
+                return LengthedBody.this.size;
             }
         };
     }


### PR DESCRIPTION
- add interface LengthedReadableByteChannel implemented by anonymous class, so that it is possible to check for this class/interface using `instanceof`