### PR TITLE
Improve logging of MediaType parse errors

### DIFF
--- a/src/org/netpreserve/jwarc/MediaType.java
+++ b/src/org/netpreserve/jwarc/MediaType.java
@@ -16,7 +16,7 @@ import java.util.*;
 // line 53 "MediaType.rl"
 
 
-public class MediaType {
+public class MediaType extends MessageParser {
     private static BitSet tokenChars = new BitSet();
     static {
         "!#$%&'*+-.^_`|~ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890".chars().forEach(tokenChars::set);
@@ -296,7 +296,7 @@ case 1:
 // line 29 "MediaType.rl"
 	{
         if (p >= 0) { /* this if statement is just to stop javac complaining about unreachable code */
-            throw new IllegalArgumentException("parse error at position " + p + " near " + string.substring(p));
+            throw new IllegalArgumentException("parse error at position " + p + ": " + getErrorContext(string, p, 40));
         }
     }
 	break;
@@ -377,7 +377,7 @@ case 4:
 // line 29 "MediaType.rl"
 	{
         if (p >= 0) { /* this if statement is just to stop javac complaining about unreachable code */
-            throw new IllegalArgumentException("parse error at position " + p + " near " + string.substring(p));
+            throw new IllegalArgumentException("parse error at position " + p + ": " + getErrorContext(string, p, 40));
         }
     }
 	break;

--- a/src/org/netpreserve/jwarc/MediaType.rl
+++ b/src/org/netpreserve/jwarc/MediaType.rl
@@ -28,7 +28,7 @@ import java.util.*;
 
     action parse_error {
         if (p >= 0) { /* this if statement is just to stop javac complaining about unreachable code */
-            throw new IllegalArgumentException("parse error at position " + p + " near " + string.substring(p));
+            throw new IllegalArgumentException("parse error at position " + p + ": " + getErrorContext(string, p, 40));
         }
     }
 
@@ -52,7 +52,7 @@ import java.util.*;
 
 }%%
 
-public class MediaType {
+public class MediaType extends MessageParser {
     private static BitSet tokenChars = new BitSet();
     static {
         "!#$%&'*+-.^_`|~ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890".chars().forEach(tokenChars::set);

--- a/src/org/netpreserve/jwarc/MessageParser.java
+++ b/src/org/netpreserve/jwarc/MessageParser.java
@@ -9,6 +9,28 @@ import java.nio.ByteBuffer;
 
 public class MessageParser {
 
+    protected static String getErrorContext(String input, int position, int length) {
+        StringBuilder context = new StringBuilder();
+
+        int start = position - length;
+        if (start < 0) {
+            start = 0;
+        } else {
+            context.append("...");
+        }
+        int end = Math.min(input.length(), (position + length));
+
+        context.append(input.substring(start, position));
+        context.append("<-- HERE -->");
+        context.append(input.substring(position, end));
+
+        if (end < input.length()) {
+            context.append("...");
+        }
+
+        return context.toString();
+    }
+
     protected static String getErrorContext(ByteBuffer buffer, int position, int length) {
         StringBuilder context = new StringBuilder();
 


### PR DESCRIPTION
Similar to #23:
- include also context before current position
- but limit length of shown context

Instead of
```
java.lang.IllegalArgumentException: parse error at position 25 near 
```
will show
```
java.lang.IllegalArgumentException: parse error at position 25: text/html; charset=UTF-8;<-- HERE -->
```