### PR TITLE
GzipChannel write() to return consumed bytes, fixes #44

### DIFF
--- a/src/org/netpreserve/jwarc/WarcWriter.java
+++ b/src/org/netpreserve/jwarc/WarcWriter.java
@@ -70,7 +70,8 @@ public class WarcWriter implements Closeable {
         }
         position.addAndGet(channel.write(ByteBuffer.wrap(TRAILER)));
         if (compression == WarcCompression.GZIP) {
-            position.addAndGet(((GzipChannel) channel).finish());
+            ((GzipChannel) channel).finish();
+            position.set(((GzipChannel) channel).outputPosition());
         }
     }
 

--- a/test/org/netpreserve/jwarc/GzipChannelTest.java
+++ b/test/org/netpreserve/jwarc/GzipChannelTest.java
@@ -36,7 +36,8 @@ public class GzipChannelTest {
     public void test() throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         GzipChannel channel = new GzipChannel(Channels.newChannel(baos));
-        channel.write(ByteBuffer.wrap(textBytes));
+        int written = channel.write(ByteBuffer.wrap(textBytes));
+        assertEquals(written, textBytes.length);
         channel.close();
         byte[] gzipped = baos.toByteArray();
 
@@ -85,15 +86,17 @@ public class GzipChannelTest {
     public void testMultiMember() throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         GzipChannel channel = new GzipChannel(Channels.newChannel(baos));
-        int posSecond = 0;
-        posSecond += channel.write(ByteBuffer.wrap(textBytes));
-        posSecond += channel.finish(); // finish first member
-        channel.write(ByteBuffer.wrap(textBytes));
+        int written = channel.write(ByteBuffer.wrap(textBytes));
+        assertEquals(written, textBytes.length);
+        channel.finish(); // finish first member
+        long posSecond = channel.outputPosition();
+        written = channel.write(ByteBuffer.wrap(textBytes));
+        assertEquals(written, textBytes.length);
         channel.close();
         byte[] gzipped = baos.toByteArray();
 
         checkGzip(gzipped);
-        checkGzip(Arrays.copyOfRange(gzipped, posSecond, gzipped.length));
+        checkGzip(Arrays.copyOfRange(gzipped, (int) posSecond, gzipped.length));
 
         GZIPInputStream gzis = new GZIPInputStream(new ByteArrayInputStream(gzipped));
         byte[] inBytes = new byte[8192];

--- a/test/org/netpreserve/jwarc/apitests/WarcWriterTest.java
+++ b/test/org/netpreserve/jwarc/apitests/WarcWriterTest.java
@@ -50,6 +50,9 @@ public class WarcWriterTest {
         assertEquals(warcBytes[0], (byte) 0x1f);
         assertEquals(warcBytes[1], (byte) 0x8b);
 
+        // does position indicate the end of the gzipped WARC record?
+        assertEquals(warcBytes.length, writer.position());
+
         // uncompress and check whether body is contained
         ByteArrayInputStream bais = new ByteArrayInputStream(warcBytes);
         GZIPInputStream gzin = new GZIPInputStream(bais);


### PR DESCRIPTION
- outputPosition() returns number of compressed bytes written
- adapt WarcWriter to use outputPosition() to track WARC record offsets
- extend unit tests to check for correctness of return values of write() resp. outputPosition() and record offsets hold in WarcWriter