### PR TITLE
Extract tool: add support for content-encoding `deflate` and `identity`

### DIFF
--- a/src/org/netpreserve/jwarc/IOUtils.java
+++ b/src/org/netpreserve/jwarc/IOUtils.java
@@ -105,6 +105,12 @@ public final class IOUtils {
         return new GunzipChannel(gzipped, buffer);
     }
 
+    public static ReadableByteChannel inflateChannel(ReadableByteChannel deflated) throws IOException {
+        ByteBuffer buffer = ByteBuffer.allocate(8192);
+        buffer.flip();
+        return new InflateChannel(deflated, buffer);
+    }
+
     static Socket connect(String scheme, String host, int port) throws IOException {
         Objects.requireNonNull(host);
         if ("http".equalsIgnoreCase(scheme)) {

--- a/src/org/netpreserve/jwarc/InflateChannel.java
+++ b/src/org/netpreserve/jwarc/InflateChannel.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2020 National Library of Australia and the jwarc contributors
+ */
+
+package org.netpreserve.jwarc;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+import java.util.zip.DataFormatException;
+import java.util.zip.Inflater;
+import java.util.zip.ZipException;
+
+/**
+ * A ReadableByteChannel inflating deflate-compressed content on read. Used to
+ * uncompress HTTP payload with header <code>Content-Encoding: deflate</code>.
+ */
+public class InflateChannel implements ReadableByteChannel {
+
+    private final ReadableByteChannel channel;
+    private final ByteBuffer buffer;
+    private final Inflater inflater = new Inflater(true);
+
+    public InflateChannel(ReadableByteChannel channel, ByteBuffer buffer) throws IllegalArgumentException {
+        this.channel = channel;
+        this.buffer = buffer;
+        if (!buffer.hasArray()) {
+            throw new IllegalArgumentException("ByteBuffer must be array-backed and writable");
+        }
+    }
+
+    @Override
+    public int read(ByteBuffer dest) throws IOException {
+        if (inflater.finished()) {
+            return -1;
+        }
+
+        if (inflater.needsInput()) {
+            if (!buffer.hasRemaining()) {
+                buffer.compact();
+                channel.read(buffer);
+                buffer.flip();
+            }
+            inflater.setInput(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.remaining());
+        }
+
+        try {
+            int n = inflater.inflate(dest.array(), dest.arrayOffset() + dest.position(), dest.remaining());
+            dest.position(dest.position() + n);
+
+            int newBufferPosition = buffer.limit() - inflater.getRemaining();
+            buffer.position(newBufferPosition);
+
+            return n;
+        } catch (DataFormatException e) {
+            throw new ZipException(e.getMessage());
+        }
+    }
+
+    @Override
+    public boolean isOpen() {
+        return channel.isOpen();
+    }
+
+    @Override
+    public void close() throws IOException {
+        channel.close();
+    }
+}

--- a/src/org/netpreserve/jwarc/tools/ExtractTool.java
+++ b/src/org/netpreserve/jwarc/tools/ExtractTool.java
@@ -62,9 +62,14 @@ public class ExtractTool {
         } else {
             if (contentEncodings.size() > 1) {
                 System.err.println("Multiple Content-Encodings not supported: " + contentEncodings);
+            } else if (contentEncodings.get(0).equalsIgnoreCase("identity")
+                    || contentEncodings.get(0).equalsIgnoreCase("none")) {
+                writeBody(out, payload);
             } else if (contentEncodings.get(0).equalsIgnoreCase("gzip")
                     || contentEncodings.get(0).equalsIgnoreCase("x-gzip")) {
                 writeBody(out, IOUtils.gunzipChannel(payload));
+            } else if (contentEncodings.get(0).equalsIgnoreCase("deflate")) {
+                writeBody(out, IOUtils.inflateChannel(payload));
             } else {
                 System.err.println("Content-Encoding not supported: " + contentEncodings.get(0));
             }


### PR DESCRIPTION
- add support for `Content-Encoding: deflate` ([content-encoding-deflate.warc.gz](https://github.com/iipc/jwarc/files/4795038/content-encoding-deflate.warc.gz))
- do not error on `Content-Encoding: identity` ([content-encoding-identity.warc.gz](https://github.com/iipc/jwarc/files/4795042/content-encoding-identity.warc.gz)) and `none` ([content-encoding-none.warc.gz](https://github.com/iipc/jwarc/files/4795043/content-encoding-none.warc.gz) - not standard-compliant but it's there, cf. curl/curl#3315)