### PR TITLE
GunzipChannel fails on payload with uncompressed size exceeding int_max

### DIFF
--- a/src/org/netpreserve/jwarc/GunzipChannel.java
+++ b/src/org/netpreserve/jwarc/GunzipChannel.java
@@ -88,7 +88,7 @@ class GunzipChannel implements ReadableByteChannel {
         int isize = buffer.getInt();
         inputPosition += 8;
 
-        if ((isize & 0xfffffffffL) != (inflater.getBytesWritten() & 0xfffffffffL)) {
+        if ((isize & 0xffffffffL) != (inflater.getBytesWritten() & 0xffffffffL)) {
             throw new ZipException("gzip uncompressed size mismatch");
         }
         if (crc != null && expectedCrc != crc.getValue()) {


### PR DESCRIPTION
(fixes #54)
- use modulo 2^32 when comparing lengths of uncompressed data (real length vs. indicated footer)