### PR TITLE
WarcDigest: handle SHA-2 digests, support Base64 encoding, auto-detect encoding

### DIFF
--- a/src/org/netpreserve/jwarc/WarcDigest.java
+++ b/src/org/netpreserve/jwarc/WarcDigest.java
@@ -6,6 +6,9 @@
 package org.netpreserve.jwarc;
 
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Base64;
 import java.util.Locale;
 import java.util.Objects;
 
@@ -20,12 +23,12 @@ public class WarcDigest {
             throw new IllegalArgumentException("Invalid WARC-Digest");
         }
         this.algorithm = digest.substring(0, i);
-        this.value = digest.substring(i + 1);
+        this.value = base32Encode(digest.substring(i + 1), this.algorithm);
     }
 
     public WarcDigest(String algorithm, String value) {
         this.algorithm = algorithm;
-        this.value = value;
+        this.value = base32Encode(value, algorithm);
     }
 
     public WarcDigest(String algorithm, byte[] value) {
@@ -41,12 +44,20 @@ public class WarcDigest {
         return algorithm;
     }
 
+    public String hex() {
+        return hexEncode(bytes());
+    }
+
+    public String base16() {
+        return hex();
+    }
+
     public String base32() {
         return value;
     }
 
-    public String hex() {
-        return hexEncode(bytes());
+    public String base64() {
+        return base64Encode(bytes());
     }
 
     public byte[] bytes() { return base32Decode(value); }
@@ -69,33 +80,77 @@ public class WarcDigest {
         return out.toString();
     }
 
+    static byte[] hexDecode(String data) {
+        if ((data.length() % 2) == 1) {
+            throw new IllegalArgumentException(
+                    "Length of hex-encoded string (Base16) must be a multiple of 2, but is " + data.length());
+        }
+        byte[] out = new byte[data.length() / 2];
+        for (int i = 0; i < out.length; i++) {
+            int v = Character.digit(data.charAt(i * 2), 16) << 4;
+            v += Character.digit(data.charAt(i * 2 + 1), 16);
+            out[i] = (byte) v;
+        }
+        return out;
+    }
+
     static String base32Encode(byte[] data) {
         StringBuilder out = new StringBuilder(data.length / 5 * 8);
+        int leftover = 0;
+        long bits = 0L;
         for (int i = 0; i < data.length;) {
-            long bits = 0L;
+            bits = 0L;
             for (int j = 0; j < 5; j++) {
-                bits = bits << 8 | data[i++] & 0xff;
+                if (i >= data.length) {
+                    bits = bits << 8 | 0x00;
+                    leftover++;
+                } else {
+                    bits = bits << 8 | data[i++] & 0xff;
+                }
             }
+            if (leftover > 0) break;
             for (int j = 0; j < 8; j++) {
                 out.append("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567".charAt((int) (bits >> 5 * (7 - j)) & 31));
+            }
+        }
+        if (leftover > 0) {
+            int trailing = 7 - ((5 - leftover) * 8 / 5);
+            for (int j = 0; j < (8 - trailing); j++) {
+                out.append("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567".charAt((int) (bits >> 5 * (7 - j)) & 31));
+            }
+            for (int j = 0; j < trailing; j++) {
+                out.append('=');
             }
         }
         return out.toString();
     }
 
     static byte[] base32Decode(String data) {
-        byte[] out = new byte[data.length() / 8 * 5];
+        int padding = 0;
+        int outLength = data.length() / 8 * 5;
+        if ((data.length() % 8) > 0) {
+            // missing padding
+            outLength += 5;
+        }
+        byte[] out = new byte[outLength];
         for (int i = 0, k = 0; k < out.length;) {
             long bits = 0L;
             for (int j = 0; j < 8; j++) {
-                int c = data.charAt(i++) | 'A' ^ 'a';
+                int c = '=';
+                if (i < data.length())
+                    c = data.charAt(i++) | 'A' ^ 'a';
                 int value;
                 if (c >= 'a' && c <= 'z') {
                     value = c - 'a';
                 } else if (c >= '2' && c <= '7') {
                     value = c - '2' + 26;
+                } else if (c == '=') {
+                    // padding
+                    value = 0;
+                    padding++;
                 } else {
-                    throw new IllegalArgumentException("Invalid base32 character: " + c);
+                    throw new IllegalArgumentException(
+                            "Invalid base32 character: " + c + " '" + (char) c + "'");
                 }
                 bits = bits << 5 | value;
             }
@@ -103,7 +158,38 @@ public class WarcDigest {
                 out[k++] = (byte) ((bits >> 8 * (4 - j)) & 0xff);
             }
         }
+        if (padding > 0) {
+            int trim = 5 - (43 - 5 * padding) / 8;
+            out = Arrays.copyOfRange(out, 0, (out.length - trim));
+        }
         return out;
+    }
+
+    /** Decode the digest value if it's not Base32 */
+    static String base32Encode(String value, String algorithm) {
+        try {
+            int length = getDigester(algorithm).getDigestLength();
+            if ((length * 2) == value.length()) {
+                // Base16
+                return base32Encode(hexDecode(value));
+            } else if ((length * 8 / 5) <= value.length()) {
+                // Base32
+            } else if ((length * 8 / 6) <= value.length()) {
+                // Base64
+                return base32Encode(Base64.getDecoder().decode(value));
+            }
+        } catch (NoSuchAlgorithmException e) {
+            // ignore: no way to verify the digest anyway
+        }
+        return value;
+    }
+
+    static String base64Encode(byte[] data) {
+        return Base64.getEncoder().encodeToString(data);
+    }
+
+    static byte[] base64Decode(String data) {
+        return Base64.getDecoder().decode(data);
     }
 
     @Override
@@ -118,5 +204,29 @@ public class WarcDigest {
     @Override
     public int hashCode() {
         return Objects.hash(algorithm, value);
+    }
+
+    /**
+     * Get digester for algorithm names not matching the canonical Java names, e.g.
+     * "sha256" instead of "SHA-256"
+     */
+    public static MessageDigest getDigester(String algorithm) throws NoSuchAlgorithmException {
+        try {
+            return MessageDigest.getInstance(algorithm);
+        } catch (NoSuchAlgorithmException e) {
+            // transform "sha256" to "SHA-256" and similar
+            if (algorithm.toLowerCase(Locale.ROOT).startsWith("sha")) {
+                algorithm = "SHA-" + algorithm.substring(3);
+            }
+        }
+        return MessageDigest.getInstance(algorithm);
+    }
+
+    public MessageDigest getDigester() throws NoSuchAlgorithmException {
+        return getDigester(algorithm);
+    }
+
+    public boolean equals(MessageDigest d) {
+        return false;
     }
 }

--- a/src/org/netpreserve/jwarc/WarcDigest.java
+++ b/src/org/netpreserve/jwarc/WarcDigest.java
@@ -225,8 +225,4 @@ public class WarcDigest {
     public MessageDigest getDigester() throws NoSuchAlgorithmException {
         return getDigester(algorithm);
     }
-
-    public boolean equals(MessageDigest d) {
-        return false;
-    }
 }

--- a/test/org/netpreserve/jwarc/WarcDigestTest.java
+++ b/test/org/netpreserve/jwarc/WarcDigestTest.java
@@ -5,33 +5,116 @@
 
 package org.netpreserve.jwarc;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class WarcDigestTest {
 
+    private byte[] contentBytes = "hello world".getBytes();
+
     @Test
-    public void test() throws NoSuchAlgorithmException {
+    public void testSha1() throws NoSuchAlgorithmException {
         MessageDigest md = MessageDigest.getInstance("SHA-1");
-        md.update("hello world".getBytes());
+        md.update(contentBytes);
         WarcDigest digest = new WarcDigest(md);
         assertEquals("sha1:FKXGYNOJJ7H3IFO35FPUBC445EPOQRXN", digest.prefixedBase32());
         assertEquals("FKXGYNOJJ7H3IFO35FPUBC445EPOQRXN", digest.base32());
         assertEquals("2aae6c35c94fcfb415dbe95f408b9ce91ee846ed", digest.hex());
+        assertEquals("Kq5sNclPz7QV2+lfQIuc6R7oRu0=", digest.base64());
     }
 
     @Test
-    public void test2()  {
+    public void testBase32()  {
         assertEquals("AELZ2347", WarcDigest.base32Encode(WarcDigest.base32Decode("aelz2347")));
+        // test with and without padding (although obligatory following RFC 4648)
+        assertEquals("AELZ2347AE======", WarcDigest.base32Encode(WarcDigest.base32Decode("aelz2347ae======")));
+        assertEquals("AELZ2347AE======", WarcDigest.base32Encode(WarcDigest.base32Decode("aelz2347ae")));
+    }
+
+    @Test
+    public void testBase64()  {
+        assertEquals("ARedb58B", WarcDigest.base64Encode(WarcDigest.base64Decode("ARedb58B")));
+        // test with and without padding (although obligatory following RFC 4648)
+        assertEquals("ARedb58BAQ==", WarcDigest.base64Encode(WarcDigest.base64Decode("ARedb58BAQ==")));
+        assertEquals("ARedb58BAQ==", WarcDigest.base64Encode(WarcDigest.base64Decode("ARedb58BAQ")));
     }
 
     @Test
     public void testEncodeHex() {
         assertEquals("000190ff", WarcDigest.hexEncode(new byte[]{0x00, 0x01, (byte) 0x90, (byte) 0xff}));
+        assertEquals("000190ff", WarcDigest.hexEncode(WarcDigest.hexDecode("000190ff")));
+    }
+
+    @Test
+    public void testSha224() throws NoSuchAlgorithmException {
+        MessageDigest md = MessageDigest.getInstance("SHA-224");
+        md.update(contentBytes);
+        WarcDigest digest = new WarcDigest(md);
+        assertEquals("sha224:F4CUO76CJO2PV36YMULRK3NP33HMIW4K2PHSKIVFMNMCW===", digest.prefixedBase32());
+        assertEquals("F4CUO76CJO2PV36YMULRK3NP33HMIW4K2PHSKIVFMNMCW===", digest.base32());
+        assertEquals("2f05477fc24bb4faefd86517156dafdecec45b8ad3cf2522a563582b", digest.hex());
+        assertEquals("LwVHf8JLtPrv2GUXFW2v3s7EW4rTzyUipWNYKw==", digest.base64());
+    }
+
+    @Test
+    public void testSha256() throws NoSuchAlgorithmException {
+        MessageDigest md = MessageDigest.getInstance("SHA-256");
+        md.update(contentBytes);
+        WarcDigest digest = new WarcDigest(md);
+        assertEquals("sha256:XFGSPOMTJU7ARJJOKLL5U7NL7LCIJ37DPJJYB3UQRD32ZYXPZXUQ====", digest.prefixedBase32());
+        assertEquals("XFGSPOMTJU7ARJJOKLL5U7NL7LCIJ37DPJJYB3UQRD32ZYXPZXUQ====", digest.base32());
+        assertEquals("b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9", digest.hex());
+        assertEquals("uU0nuZNNPgilLlLX2n2r+sSE7+N6U4DukIj3rOLvzek=", digest.base64());
+    }
+
+    @Test
+    public void testSha384() throws NoSuchAlgorithmException {
+        MessageDigest md = MessageDigest.getInstance("SHA-384");
+        md.update(contentBytes);
+        WarcDigest digest = new WarcDigest(md);
+        assertEquals("sha384:7W6Y45NGP4U7OANE4BADQXROEOMGGA7KCARZEENPSB74XOBVPCZ6IF6LOHHGI3X5BAM53DAIRXQ32===",
+                digest.prefixedBase32());
+        assertEquals("7W6Y45NGP4U7OANE4BADQXROEOMGGA7KCARZEENPSB74XOBVPCZ6IF6LOHHGI3X5BAM53DAIRXQ32===",
+                digest.base32());
+        assertEquals(
+                "fdbd8e75a67f29f701a4e040385e2e23986303ea10239211af907fcbb83578b3e417cb71ce646efd0819dd8c088de1bd",
+                digest.hex());
+        assertEquals("/b2OdaZ/KfcBpOBAOF4uI5hjA+oQI5IRr5B/y7g1eLPkF8txzmRu/QgZ3YwIjeG9", digest.base64());
+    }
+
+    /**
+     * Test round-trip encoding for various message digests, cf.
+     * <code>java.security.Security.getAlgorithms("MessageDigest")</code>
+     */
+    @Test
+    public void testMessageDigests() throws NoSuchAlgorithmException {
+        String[] algorithms = { "sha", "sha1", "sha224", "sha256", "sha384", "sha512", "md5" };
+        for (String algorithm : algorithms) {
+            MessageDigest md = WarcDigest.getDigester(algorithm);
+            md.update(contentBytes);
+            byte[] digest = md.digest(); // note: digest() resets the digester
+            md.update(contentBytes);
+            WarcDigest wd = new WarcDigest(md);
+            assertTrue("Digest bytes not equal for " + algorithm, Arrays.equals(wd.bytes(), digest));
+        }
+    }
+
+    @Test
+    public void testBaseEncodingAutoDetection() throws NoSuchAlgorithmException {
+        MessageDigest md = MessageDigest.getInstance("SHA-256");
+        md.update(contentBytes);
+        byte[] digest = md.digest();
+        WarcDigest wd = new WarcDigest("sha256:XFGSPOMTJU7ARJJOKLL5U7NL7LCIJ37DPJJYB3UQRD32ZYXPZXUQ====");
+        assertTrue("Bytes not equal for Base32 encoded SHA-256 digest", Arrays.equals(wd.bytes(), digest));
+        wd = new WarcDigest("sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9");
+        assertTrue("Bytes not equal for Base16 encoded SHA-256 digest", Arrays.equals(wd.bytes(), digest));
+        wd = new WarcDigest("sha256:uU0nuZNNPgilLlLX2n2r+sSE7+N6U4DukIj3rOLvzek=");
+        assertTrue("Bytes not equal for Base64 encoded SHA-256 digest", Arrays.equals(wd.bytes(), digest));
     }
 }


### PR DESCRIPTION
- handle SHA-2 digests (SHA-256, etc.)
  - utility method `getDigest()` to support WARC digest algorithm names which are not valid Java [MessageDigest](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/security/MessageDigest.html) identifiers - eg. `sha256` needs to be `SHA-256`, otherwise a [NoSuchAlgorithmException](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/security/NoSuchAlgorithmException.html) is thrown
  - support for padding of Base32 encoded digests
- add support for Base64 digest encoding
- auto-detect encoding of digests by value length when parsing digest strings in WARC files, convert to Base32 if needed