### PR TITLE
Add validate tool

### DIFF
--- a/src/org/netpreserve/jwarc/DigestingMessageBody.java
+++ b/src/org/netpreserve/jwarc/DigestingMessageBody.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2021 National Library of Australia and the jwarc contributors
+ */
+
+package org.netpreserve.jwarc;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.security.MessageDigest;
+
+/**
+ * Wrapper around a MessageBody which calculates a MessageDigest while the body
+ * is read.
+ */
+public class DigestingMessageBody extends MessageBody {
+
+    public MessageBody body;
+    public MessageDigest digest;
+    public long length = 0;
+
+    public DigestingMessageBody(MessageBody digestedBody, MessageDigest digest) {
+        this.body = digestedBody;
+        this.digest = digest;
+    }
+
+    @Override
+    public int read(ByteBuffer dst) throws IOException {
+        int i = body.read(dst);
+        int pos = dst.position();
+        length += (dst.limit() - pos);
+        digest.update(dst);
+        // rewind buffer position, so that data can be consumed a second time 
+        dst.position(pos);
+        return i;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return body.isOpen();
+    }
+
+    @Override
+    public void close() throws IOException {
+        body.close();
+    }
+
+    @Override
+    public long position() throws IOException {
+        return body.position();
+    }
+
+    public MessageDigest getDigest() {
+        return digest;
+    }
+
+    public long getLength() {
+        return length;
+    }
+}

--- a/src/org/netpreserve/jwarc/WarcDigest.java
+++ b/src/org/netpreserve/jwarc/WarcDigest.java
@@ -6,6 +6,9 @@
 package org.netpreserve.jwarc;
 
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Base64;
 import java.util.Locale;
 import java.util.Objects;
 
@@ -20,12 +23,12 @@ public class WarcDigest {
             throw new IllegalArgumentException("Invalid WARC-Digest");
         }
         this.algorithm = digest.substring(0, i);
-        this.value = digest.substring(i + 1);
+        this.value = base32Encode(digest.substring(i + 1), this.algorithm);
     }
 
     public WarcDigest(String algorithm, String value) {
         this.algorithm = algorithm;
-        this.value = value;
+        this.value = base32Encode(value, algorithm);
     }
 
     public WarcDigest(String algorithm, byte[] value) {
@@ -41,12 +44,20 @@ public class WarcDigest {
         return algorithm;
     }
 
+    public String hex() {
+        return hexEncode(bytes());
+    }
+
+    public String base16() {
+        return hex();
+    }
+
     public String base32() {
         return value;
     }
 
-    public String hex() {
-        return hexEncode(bytes());
+    public String base64() {
+        return base64Encode(bytes());
     }
 
     public byte[] bytes() { return base32Decode(value); }
@@ -69,33 +80,77 @@ public class WarcDigest {
         return out.toString();
     }
 
+    static byte[] hexDecode(String data) {
+        if ((data.length() % 2) == 1) {
+            throw new IllegalArgumentException(
+                    "Length of hex-encoded string (Base16) must be a multiple of 2, but is " + data.length());
+        }
+        byte[] out = new byte[data.length() / 2];
+        for (int i = 0; i < out.length; i++) {
+            int v = Character.digit(data.charAt(i * 2), 16) << 4;
+            v += Character.digit(data.charAt(i * 2 + 1), 16);
+            out[i] = (byte) v;
+        }
+        return out;
+    }
+
     static String base32Encode(byte[] data) {
         StringBuilder out = new StringBuilder(data.length / 5 * 8);
+        int leftover = 0;
+        long bits = 0L;
         for (int i = 0; i < data.length;) {
-            long bits = 0L;
+            bits = 0L;
             for (int j = 0; j < 5; j++) {
-                bits = bits << 8 | data[i++] & 0xff;
+                if (i >= data.length) {
+                    bits = bits << 8 | 0x00;
+                    leftover++;
+                } else {
+                    bits = bits << 8 | data[i++] & 0xff;
+                }
             }
+            if (leftover > 0) break;
             for (int j = 0; j < 8; j++) {
                 out.append("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567".charAt((int) (bits >> 5 * (7 - j)) & 31));
+            }
+        }
+        if (leftover > 0) {
+            int trailing = 7 - ((5 - leftover) * 8 / 5);
+            for (int j = 0; j < (8 - trailing); j++) {
+                out.append("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567".charAt((int) (bits >> 5 * (7 - j)) & 31));
+            }
+            for (int j = 0; j < trailing; j++) {
+                out.append('=');
             }
         }
         return out.toString();
     }
 
     static byte[] base32Decode(String data) {
-        byte[] out = new byte[data.length() / 8 * 5];
+        int padding = 0;
+        int outLength = data.length() / 8 * 5;
+        if ((data.length() % 8) > 0) {
+            // missing padding
+            outLength += 5;
+        }
+        byte[] out = new byte[outLength];
         for (int i = 0, k = 0; k < out.length;) {
             long bits = 0L;
             for (int j = 0; j < 8; j++) {
-                int c = data.charAt(i++) | 'A' ^ 'a';
+                int c = '=';
+                if (i < data.length())
+                    c = data.charAt(i++) | 'A' ^ 'a';
                 int value;
                 if (c >= 'a' && c <= 'z') {
                     value = c - 'a';
                 } else if (c >= '2' && c <= '7') {
                     value = c - '2' + 26;
+                } else if (c == '=') {
+                    // padding
+                    value = 0;
+                    padding++;
                 } else {
-                    throw new IllegalArgumentException("Invalid base32 character: " + c);
+                    throw new IllegalArgumentException(
+                            "Invalid base32 character: " + c + " '" + (char) c + "'");
                 }
                 bits = bits << 5 | value;
             }
@@ -103,7 +158,38 @@ public class WarcDigest {
                 out[k++] = (byte) ((bits >> 8 * (4 - j)) & 0xff);
             }
         }
+        if (padding > 0) {
+            int trim = 5 - (43 - 5 * padding) / 8;
+            out = Arrays.copyOfRange(out, 0, (out.length - trim));
+        }
         return out;
+    }
+
+    /** Decode the digest value if it's not Base32 */
+    static String base32Encode(String value, String algorithm) {
+        try {
+            int length = getDigester(algorithm).getDigestLength();
+            if ((length * 2) == value.length()) {
+                // Base16
+                return base32Encode(hexDecode(value));
+            } else if ((length * 8 / 5) <= value.length()) {
+                // Base32
+            } else if ((length * 8 / 6) <= value.length()) {
+                // Base64
+                return base32Encode(Base64.getDecoder().decode(value));
+            }
+        } catch (NoSuchAlgorithmException e) {
+            // ignore: no way to verify the digest anyway
+        }
+        return value;
+    }
+
+    static String base64Encode(byte[] data) {
+        return Base64.getEncoder().encodeToString(data);
+    }
+
+    static byte[] base64Decode(String data) {
+        return Base64.getDecoder().decode(data);
     }
 
     @Override
@@ -118,5 +204,29 @@ public class WarcDigest {
     @Override
     public int hashCode() {
         return Objects.hash(algorithm, value);
+    }
+
+    /**
+     * Get digester for algorithm names not matching the canonical Java names, e.g.
+     * "sha256" instead of "SHA-256"
+     */
+    public static MessageDigest getDigester(String algorithm) throws NoSuchAlgorithmException {
+        try {
+            return MessageDigest.getInstance(algorithm);
+        } catch (NoSuchAlgorithmException e) {
+            // transform "sha256" to "SHA-256" and similar
+            if (algorithm.toLowerCase(Locale.ROOT).startsWith("sha")) {
+                algorithm = "SHA-" + algorithm.substring(3);
+            }
+        }
+        return MessageDigest.getInstance(algorithm);
+    }
+
+    public MessageDigest getDigester() throws NoSuchAlgorithmException {
+        return getDigester(algorithm);
+    }
+
+    public boolean equals(MessageDigest d) {
+        return false;
     }
 }

--- a/src/org/netpreserve/jwarc/WarcDigest.java
+++ b/src/org/netpreserve/jwarc/WarcDigest.java
@@ -225,8 +225,4 @@ public class WarcDigest {
     public MessageDigest getDigester() throws NoSuchAlgorithmException {
         return getDigester(algorithm);
     }
-
-    public boolean equals(MessageDigest d) {
-        return false;
-    }
 }

--- a/src/org/netpreserve/jwarc/WarcReader.java
+++ b/src/org/netpreserve/jwarc/WarcReader.java
@@ -23,7 +23,7 @@ import static java.util.Spliterators.spliteratorUnknownSize;
 
 public class WarcReader implements Iterable<WarcRecord>, Closeable {
     private static final int CRLFCRLF = 0x0d0a0d0a;
-    private static final Map<String, WarcRecord.Constructor> defaultTypes = initDefaultTypes();
+    public static final Map<String, WarcRecord.Constructor> defaultTypes = initDefaultTypes();
     private final HashMap<String, WarcRecord.Constructor> types;
     private final WarcParser parser = new WarcParser();
     private final ReadableByteChannel channel;

--- a/src/org/netpreserve/jwarc/WarcReader.java
+++ b/src/org/netpreserve/jwarc/WarcReader.java
@@ -13,6 +13,8 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.*;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -23,7 +25,7 @@ import static java.util.Spliterators.spliteratorUnknownSize;
 
 public class WarcReader implements Iterable<WarcRecord>, Closeable {
     private static final int CRLFCRLF = 0x0d0a0d0a;
-    public static final Map<String, WarcRecord.Constructor> defaultTypes = initDefaultTypes();
+    private static final Map<String, WarcRecord.Constructor> defaultTypes = initDefaultTypes();
     private final HashMap<String, WarcRecord.Constructor> types;
     private final WarcParser parser = new WarcParser();
     private final ReadableByteChannel channel;
@@ -33,6 +35,7 @@ public class WarcReader implements Iterable<WarcRecord>, Closeable {
     private final long startPosition;
     private long position;
     private long headerLength;
+    private boolean blockDigestCalculation = false;
 
     /**
      * Create WarcReader with user-provided buffer. Data contained in the buffer is
@@ -155,6 +158,18 @@ public class WarcReader implements Iterable<WarcRecord>, Closeable {
         MessageHeaders headers = parser.headers();
         long contentLength = headers.sole("Content-Length").map(Long::parseLong).orElse(0L);
         MessageBody body = LengthedBody.create(channel, buffer, contentLength);
+        if (blockDigestCalculation) {
+            Optional<String> blockDigestHeader = headers.sole("WARC-Block-Digest");
+            if (blockDigestHeader.isPresent()) {
+                try {
+                    MessageDigest md = (new WarcDigest(blockDigestHeader.get())).getDigester();
+                    body = new DigestingMessageBody(body, md);
+                } catch (NoSuchAlgorithmException e) {
+                    // ignore in order to be able to read also WARC records with unknown digest algorithm
+                    //throw new IOException("Failed to calculate block digest", e);
+                }
+            }
+        }
         record = construct(parser.version(), headers, body);
         return Optional.of(record);
     }
@@ -207,6 +222,18 @@ public class WarcReader implements Iterable<WarcRecord>, Closeable {
      */
     public void registerType(String type, WarcRecord.Constructor<WarcRecord> constructor) {
         types.put(type, constructor);
+    }
+
+    /**
+     * Enable calculation of block digests for all WARC records which include the
+     * header "WARC-Block-Digest" and using the same digest algorithm as mentioned
+     * in the header. The actually calculated record digests
+     * ({@link WarcRecord#calculatedBlockDigest()}) can be then compared to the
+     * pre-calculated digests ({@link WarcRecord#blockDigest()}). See also
+     * {@link DigestingMessageBody}.
+     */
+    public void calculateBlockDigest() {
+        blockDigestCalculation  = true;
     }
 
     /**

--- a/src/org/netpreserve/jwarc/tools/ValidateTool.java
+++ b/src/org/netpreserve/jwarc/tools/ValidateTool.java
@@ -1,0 +1,291 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2021 National Library of Australia and the jwarc contributors
+ */
+
+package org.netpreserve.jwarc.tools;
+
+import org.netpreserve.jwarc.*;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Paths;
+import java.security.DigestException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
+
+public class ValidateTool extends WarcTool {
+
+    private final static MediaType DNS = MediaType.parse("text/dns");
+
+    private static class Logger {
+        protected Optional<StringBuilder> sb;
+        public Logger() {
+            this.sb = Optional.of(new StringBuilder());
+        }
+        public void log(String form) {
+            sb.ifPresent(s -> s.append("    ").append(form).append('\n'));
+        }
+        public void log(String form, Object... args) {
+            sb.ifPresent(s -> s.append("    ").append(String.format(form, args)).append('\n'));
+        }
+        public void error(String form, Object... args) {
+            if (sb.isPresent()) {
+                log("ERROR: " + form, args);
+            } else {
+                System.err.println("ERROR: " + String.format(form, args));
+            }
+        }
+        public void exception(String message, Exception e) {
+            if (sb.isPresent()) {
+                log("ERROR: %s: %s", message, e);
+            } else {
+                System.err.println("ERROR: " + message + ": " + e);
+            }
+        }
+        public String print() {
+            String res = "";
+            if (sb.isPresent()) {
+                res = sb.get().toString();
+                sb.get().setLength(0);
+            }
+            return res;
+        }
+    }
+
+    private static class NonVerboseLogger extends Logger {
+        public NonVerboseLogger() {
+            this.sb = Optional.empty();
+        }
+    }
+
+    private Logger logger;
+    private boolean verbose;
+    private Optional<DigestingMessageBody> blockDigestBody = Optional.empty();
+
+    public ValidateTool(boolean verbose) {
+        this.verbose = verbose;
+        if (verbose) {
+            logger = new Logger();
+        } else {
+            logger = new NonVerboseLogger();
+        }
+    }
+
+    private static long readBody(MessageBody body, Consumer<ByteBuffer> consumer) throws IOException {
+        long size = 0;
+        int i = 0;
+        ByteBuffer buffer = ByteBuffer.allocate(8192);
+        while ((i = body.read(buffer)) > -1) {
+            size += i;
+            consumer.accept(buffer);
+            buffer.compact();
+        }
+        return size;
+    }
+
+    private static void validateDigest(WarcDigest digestExpected, WarcDigest digestCalculated, long size)
+            throws DigestException {
+        if (!digestCalculated.equals(digestCalculated)) {
+            throw new java.security.DigestException("Failed to validate digest: expected " + digestExpected + ", got "
+                    + digestCalculated + " (on " + size + " bytes)");
+        }
+    }
+
+    private static void validateDigest(MessageBody body, WarcDigest digest, AtomicLong consumedBytes)
+            throws IOException, NoSuchAlgorithmException, DigestException {
+        MessageDigest md = digest.getDigester();
+        long size = readBody(body, b -> md.update(b));
+        consumedBytes.set(size);
+        WarcDigest dig = new WarcDigest(md);
+        validateDigest(digest, dig, size);
+    }
+
+    /**
+     * Wrap the record body into a DigestingMessageBody in order to verify the
+     * WARC-Block-Digest. and update the digest while the parser reads the body
+     */
+    private WarcRecord wrapDigestingBody(WarcRecord record) {
+        if (record.blockDigest().isPresent()) {
+            try {
+                MessageDigest md = record.blockDigest().get().getDigester();
+                blockDigestBody = Optional.of(new DigestingMessageBody(record.body(), md));
+                return WarcReader.defaultTypes.get(record.type()).construct(record.version(), record.headers(),
+                        blockDigestBody.get());
+            } catch (NoSuchAlgorithmException e) {
+                blockDigestBody = Optional.empty();
+                logger.log("digest unknown algorithm: %s", e.getMessage());
+            }
+        } else {
+            blockDigestBody = Optional.empty();
+        }
+        return record;
+    }
+
+    private boolean validateCapture(WarcRecord record) throws IOException {
+        boolean valid = true;
+        int contentLength = -1;
+        String targetUri = ((WarcTargetRecord) record).target();
+        logger.log(targetUri);
+        if (record instanceof WarcResponse && record.contentType().equals(MediaType.HTTP_RESPONSE)) {
+            HttpResponse http = ((WarcResponse) record).http();
+            logger.log("%s %d %s", http.version(), http.status(), http.reason());
+            Optional<String> contentLengthHeader = http.headers().first("content-length");
+            if (contentLengthHeader.isPresent()) {
+                try {
+                    contentLength = Integer.parseInt(contentLengthHeader.get());
+                } catch (NumberFormatException e) {
+                    logger.error("failed to read HTTP Content-Length header: %s", contentLengthHeader.get());
+                    valid = false;
+                }
+            }
+        } else if (record instanceof WarcRequest && record.contentType().equals(MediaType.HTTP_REQUEST)) {
+            HttpRequest http = ((WarcRequest) record).http();
+            logger.log("%s %s", http.version(), http.method());
+        } else if (record instanceof WarcResponse && record.contentType().equals(DNS)) {
+            // DNS record
+        } else {
+            // WarcResource, WarcMetadata, etc. - nothing special to validate
+        }
+        logger.log("date: %s", record.date());
+        Optional<WarcPayload> payload = ((WarcCaptureRecord) record).payload();
+        if (payload.isPresent()) {
+            MediaType type;
+            try {
+                type = payload.get().type().base();
+                logger.log("payload media type: %s", type);
+            } catch (IllegalArgumentException e) {
+                logger.exception("Parsing Content-Type failed", e);
+                type = MediaType.OCTET_STREAM;
+            }
+            Optional<WarcDigest> pdigest = payload.get().digest();
+            long length = -1;
+            if (pdigest.isPresent()) {
+                AtomicLong plength = new AtomicLong(length);
+                try {
+                    validateDigest(payload.get().body(), pdigest.get(), plength);
+                    logger.log("payload digest pass");
+                } catch (DigestException e) {
+                    logger.error("payload digest failed: %s", e.getMessage());
+                    valid = false;
+                } catch (NoSuchAlgorithmException e) {
+                    logger.log("digest unknown algorithm: %s", e.getMessage());
+                }
+                length = plength.get();
+            } else {
+                length = readBody(payload.get().body(), b -> b.rewind());
+            }
+            if (contentLength > 0 && contentLength != length) {
+                logger.error("invalid HTTP header Content-Length: %d", contentLength);
+                valid = false;
+            }
+        }
+        return valid;
+    }
+
+    private boolean validate(WarcReader reader) throws IOException {
+        boolean warcValidates = true;
+        WarcRecord record = reader.next().orElse(null);
+        while (record != null) {
+            boolean valid = true;
+
+            record = wrapDigestingBody(record);
+
+            if (record instanceof WarcCaptureRecord) {
+                try {
+                    valid = validateCapture(record);
+                } catch (IOException e) {
+                    // keep going (try at least)
+                    logger.exception("Exception during validation", e);
+                    valid = false;
+                }
+            } else {
+                /*
+                 * no special verification for non-capture record types (WarcContinuation,
+                 * WarcConversion), just consume the body
+                 */
+                record.body().consume();
+            }
+
+            if (record.blockDigest().isPresent() && blockDigestBody.isPresent()) {
+                try {
+                    validateDigest(record.blockDigest().get(), new WarcDigest(blockDigestBody.get().getDigest()),
+                            blockDigestBody.get().getLength());
+                    logger.log("block digest pass");
+                } catch (DigestException e) {
+                    logger.error("block digest failed: %s", e.getMessage());
+                    valid = false;
+                }
+            }
+
+            String recordType = record.type();
+            MediaType contentType = record.contentType();
+            long position = reader.position();
+
+            record = reader.next().orElse(null);
+            long length = reader.position() - position;
+
+            if (verbose) {
+                System.out.printf("  offset %d (length %d) %s %s\n%s", position, length, recordType, contentType,
+                        logger.print());
+            } else if (!valid) {
+                System.err.printf("  offset %d (length %d) %s %s failed\n", position, length, recordType, contentType);
+            }
+
+            if (!valid) {
+                warcValidates = false;
+            }
+        }
+        return warcValidates;
+    }
+
+    private static void usage(int exitValue) {
+        System.err.println("");
+        System.err.println("ValidateTool [-h] [-v] filename...");
+        System.err.println("");
+        System.err.println("Options:");
+        System.err.println("");
+        System.err.println(" -h / --help\tshow usage message and exit");
+        System.err.println(" -v / --verbose\tlog information about every WARC record to stdout");
+        System.err.println("");
+        System.err.println("Exit value is 0 if all WARC/ARC files validate, 1 otherwise.");
+        System.err.println("Errors and erroneous WARC/ARC records are logged to stderr.");
+        System.err.println("");
+        System.exit(exitValue);
+    }
+
+    public static void main(String[] args) throws IOException {
+        int res = 0;
+        boolean verbose = false;
+        if (args.length == 0)
+            usage(0);
+        for (String arg : args) {
+            switch (arg) {
+                case "-h":
+                case "--help":
+                    usage(0);
+                    break;
+                case "-v":
+                case "--verbose":
+                    verbose = true;
+                    break;
+                default:
+                    ValidateTool validator = new ValidateTool(verbose);
+                    try (WarcReader reader = new WarcReader(Paths.get(arg))) {
+                        if (verbose)
+                            System.out.println("Validating " + arg);
+                        if (!validator.validate(reader)) {
+                            System.err.println("Failed to validate " + arg);
+                            res = 1;
+                        }
+                    }
+            }
+        }
+        System.exit(res);
+    }
+
+}

--- a/src/org/netpreserve/jwarc/tools/WarcTool.java
+++ b/src/org/netpreserve/jwarc/tools/WarcTool.java
@@ -45,6 +45,9 @@ public class WarcTool {
             case "serve":
                 ServeTool.main(rest);
                 break;
+            case "validate":
+                ValidateTool.main(rest);
+                break;
             case "--version":
             case "version":
                 version();
@@ -70,6 +73,7 @@ public class WarcTool {
         System.out.println("  saveback    Saves wayback-style replayed pages as WARC records");
         System.out.println("  screenshot  Take a screenshot of each page in the given WARCs");
         System.out.println("  serve       Serve WARC files with a basic replay server/proxy");
+        System.out.println("  validate    Validate WARC or ARC files");
         System.out.println("  version     Print version information");
     }
 

--- a/test/org/netpreserve/jwarc/WarcDigestTest.java
+++ b/test/org/netpreserve/jwarc/WarcDigestTest.java
@@ -5,33 +5,116 @@
 
 package org.netpreserve.jwarc;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class WarcDigestTest {
 
+    private byte[] contentBytes = "hello world".getBytes();
+
     @Test
-    public void test() throws NoSuchAlgorithmException {
+    public void testSha1() throws NoSuchAlgorithmException {
         MessageDigest md = MessageDigest.getInstance("SHA-1");
-        md.update("hello world".getBytes());
+        md.update(contentBytes);
         WarcDigest digest = new WarcDigest(md);
         assertEquals("sha1:FKXGYNOJJ7H3IFO35FPUBC445EPOQRXN", digest.prefixedBase32());
         assertEquals("FKXGYNOJJ7H3IFO35FPUBC445EPOQRXN", digest.base32());
         assertEquals("2aae6c35c94fcfb415dbe95f408b9ce91ee846ed", digest.hex());
+        assertEquals("Kq5sNclPz7QV2+lfQIuc6R7oRu0=", digest.base64());
     }
 
     @Test
-    public void test2()  {
+    public void testBase32()  {
         assertEquals("AELZ2347", WarcDigest.base32Encode(WarcDigest.base32Decode("aelz2347")));
+        // test with and without padding (although obligatory following RFC 4648)
+        assertEquals("AELZ2347AE======", WarcDigest.base32Encode(WarcDigest.base32Decode("aelz2347ae======")));
+        assertEquals("AELZ2347AE======", WarcDigest.base32Encode(WarcDigest.base32Decode("aelz2347ae")));
+    }
+
+    @Test
+    public void testBase64()  {
+        assertEquals("ARedb58B", WarcDigest.base64Encode(WarcDigest.base64Decode("ARedb58B")));
+        // test with and without padding (although obligatory following RFC 4648)
+        assertEquals("ARedb58BAQ==", WarcDigest.base64Encode(WarcDigest.base64Decode("ARedb58BAQ==")));
+        assertEquals("ARedb58BAQ==", WarcDigest.base64Encode(WarcDigest.base64Decode("ARedb58BAQ")));
     }
 
     @Test
     public void testEncodeHex() {
         assertEquals("000190ff", WarcDigest.hexEncode(new byte[]{0x00, 0x01, (byte) 0x90, (byte) 0xff}));
+        assertEquals("000190ff", WarcDigest.hexEncode(WarcDigest.hexDecode("000190ff")));
+    }
+
+    @Test
+    public void testSha224() throws NoSuchAlgorithmException {
+        MessageDigest md = MessageDigest.getInstance("SHA-224");
+        md.update(contentBytes);
+        WarcDigest digest = new WarcDigest(md);
+        assertEquals("sha224:F4CUO76CJO2PV36YMULRK3NP33HMIW4K2PHSKIVFMNMCW===", digest.prefixedBase32());
+        assertEquals("F4CUO76CJO2PV36YMULRK3NP33HMIW4K2PHSKIVFMNMCW===", digest.base32());
+        assertEquals("2f05477fc24bb4faefd86517156dafdecec45b8ad3cf2522a563582b", digest.hex());
+        assertEquals("LwVHf8JLtPrv2GUXFW2v3s7EW4rTzyUipWNYKw==", digest.base64());
+    }
+
+    @Test
+    public void testSha256() throws NoSuchAlgorithmException {
+        MessageDigest md = MessageDigest.getInstance("SHA-256");
+        md.update(contentBytes);
+        WarcDigest digest = new WarcDigest(md);
+        assertEquals("sha256:XFGSPOMTJU7ARJJOKLL5U7NL7LCIJ37DPJJYB3UQRD32ZYXPZXUQ====", digest.prefixedBase32());
+        assertEquals("XFGSPOMTJU7ARJJOKLL5U7NL7LCIJ37DPJJYB3UQRD32ZYXPZXUQ====", digest.base32());
+        assertEquals("b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9", digest.hex());
+        assertEquals("uU0nuZNNPgilLlLX2n2r+sSE7+N6U4DukIj3rOLvzek=", digest.base64());
+    }
+
+    @Test
+    public void testSha384() throws NoSuchAlgorithmException {
+        MessageDigest md = MessageDigest.getInstance("SHA-384");
+        md.update(contentBytes);
+        WarcDigest digest = new WarcDigest(md);
+        assertEquals("sha384:7W6Y45NGP4U7OANE4BADQXROEOMGGA7KCARZEENPSB74XOBVPCZ6IF6LOHHGI3X5BAM53DAIRXQ32===",
+                digest.prefixedBase32());
+        assertEquals("7W6Y45NGP4U7OANE4BADQXROEOMGGA7KCARZEENPSB74XOBVPCZ6IF6LOHHGI3X5BAM53DAIRXQ32===",
+                digest.base32());
+        assertEquals(
+                "fdbd8e75a67f29f701a4e040385e2e23986303ea10239211af907fcbb83578b3e417cb71ce646efd0819dd8c088de1bd",
+                digest.hex());
+        assertEquals("/b2OdaZ/KfcBpOBAOF4uI5hjA+oQI5IRr5B/y7g1eLPkF8txzmRu/QgZ3YwIjeG9", digest.base64());
+    }
+
+    /**
+     * Test round-trip encoding for various message digests, cf.
+     * <code>java.security.Security.getAlgorithms("MessageDigest")</code>
+     */
+    @Test
+    public void testMessageDigests() throws NoSuchAlgorithmException {
+        String[] algorithms = { "sha", "sha1", "sha224", "sha256", "sha384", "sha512", "md5" };
+        for (String algorithm : algorithms) {
+            MessageDigest md = WarcDigest.getDigester(algorithm);
+            md.update(contentBytes);
+            byte[] digest = md.digest(); // note: digest() resets the digester
+            md.update(contentBytes);
+            WarcDigest wd = new WarcDigest(md);
+            assertTrue("Digest bytes not equal for " + algorithm, Arrays.equals(wd.bytes(), digest));
+        }
+    }
+
+    @Test
+    public void testBaseEncodingAutoDetection() throws NoSuchAlgorithmException {
+        MessageDigest md = MessageDigest.getInstance("SHA-256");
+        md.update(contentBytes);
+        byte[] digest = md.digest();
+        WarcDigest wd = new WarcDigest("sha256:XFGSPOMTJU7ARJJOKLL5U7NL7LCIJ37DPJJYB3UQRD32ZYXPZXUQ====");
+        assertTrue("Bytes not equal for Base32 encoded SHA-256 digest", Arrays.equals(wd.bytes(), digest));
+        wd = new WarcDigest("sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9");
+        assertTrue("Bytes not equal for Base16 encoded SHA-256 digest", Arrays.equals(wd.bytes(), digest));
+        wd = new WarcDigest("sha256:uU0nuZNNPgilLlLX2n2r+sSE7+N6U4DukIj3rOLvzek=");
+        assertTrue("Bytes not equal for Base64 encoded SHA-256 digest", Arrays.equals(wd.bytes(), digest));
     }
 }


### PR DESCRIPTION
Add tool to validate WARC/ARC files: verify digests, Content-Length headers, media type syntax, syntax of (parse errors in) HTTP headers. Read the payload to find/trigger errors when decoding transfer or content encoding.

Note: #59 is required to properly verify digests.

```
$> java -cp target/jwarc-*.jar org.netpreserve.jwarc.tools.WarcTool validate

ValidateTool [-h] [-v] filename...

Options:

 -h / --help    show usage message and exit
 -v / --verbose log information about every WARC record to stdout

Exit value is 0 if all WARC files validate, 1 otherwise.
Errors and erroneous WARC records are logged to stderr.

$> java -cp target/jwarc-*.jar org.netpreserve.jwarc.tools.WarcTool validate -v test-resources/org/netpreserve/jwarc/cc.warc.gz 
Validating test-resources/org/netpreserve/jwarc/cc.warc.gz
  offset 0 (length 5392) response application/http;msgtype=response
    http://commoncrawl.org/
    HTTP/1.1 200 OK
    date: 2019-12-10T10:00:01Z
    payload media type: text/html
    payload digest pass
    block digest pass
```
