### PR TITLE
Request/Response Builder with String targetURI

### DIFF
--- a/src/org/netpreserve/jwarc/WarcRequest.java
+++ b/src/org/netpreserve/jwarc/WarcRequest.java
@@ -51,8 +51,12 @@ public class WarcRequest extends WarcCaptureRecord {
 
     public static class Builder extends AbstractBuilder<WarcRequest, Builder> {
         public Builder(URI targetURI) {
+            this(targetURI.toString());
+        }
+
+        public Builder(String targetURI) {
             super("request");
-            setHeader("WARC-Target-URI", targetURI.toString());
+            setHeader("WARC-Target-URI", targetURI);
         }
 
         @Override

--- a/src/org/netpreserve/jwarc/WarcResponse.java
+++ b/src/org/netpreserve/jwarc/WarcResponse.java
@@ -72,8 +72,12 @@ public class WarcResponse extends WarcCaptureRecord {
 
     public static class Builder extends AbstractBuilder<WarcResponse, Builder> {
         public Builder(URI targetURI) {
+            this(targetURI.toString());
+        }
+
+        public Builder(String targetURI) {
             super("response");
-            setHeader("WARC-Target-URI", targetURI.toString());
+            setHeader("WARC-Target-URI", targetURI);
         }
 
         public Builder body(HttpResponse httpResponse) throws IOException {


### PR DESCRIPTION
An additional constructor has been added to the WarcRequest.Builder and the WarcResponse.Builder that accepts a String instead of a URI, to support real-world uri strings that are not valid according to the Java URI class [RFC 2396].

https://github.com/iipc/jwarc/issues/63
