### PR TITLE
Add WarcRevisit Builder with String targetURI

### DIFF
--- a/src/org/netpreserve/jwarc/WarcRevisit.java
+++ b/src/org/netpreserve/jwarc/WarcRevisit.java
@@ -122,6 +122,12 @@ public class WarcRevisit extends WarcCaptureRecord {
             setHeader("WARC-Profile", profile.toString());
         }
 
+        public Builder(String targetURI, URI profile) {
+            super("revisit");
+            setHeader("WARC-Target-URI", targetURI);
+            setHeader("WARC-Profile", profile.toString());
+        }
+
         @Override
         public WarcRevisit build() {
             return build(WarcRevisit::new);


### PR DESCRIPTION
Similar to https://github.com/iipc/jwarc/issues/63 I have added an additional constructor to accept a String instead of an URI when building a WarcRevisit.
