### PR TITLE
Implemented github-73. Keeping WARC payload digest unchanged for CDX

### DIFF
--- a/src/org/netpreserve/jwarc/WarcTargetRecord.java
+++ b/src/org/netpreserve/jwarc/WarcTargetRecord.java
@@ -56,6 +56,14 @@ public abstract class WarcTargetRecord extends WarcRecord {
     }
 
     /**
+    * Return the payload digest value directly
+    */
+   public Optional<String> payloadDigestUnchanged() {
+       return headers().sole("WARC-Payload-Digest");
+   }
+
+    
+    /**
      * A content-type that was identified by an independent check (not just what the server said).
      */
     public Optional<MediaType> identifiedPayloadType() {

--- a/src/org/netpreserve/jwarc/cdx/CdxFields.java
+++ b/src/org/netpreserve/jwarc/cdx/CdxFields.java
@@ -32,12 +32,21 @@ public final class CdxFields {
     private static String escape(String str) {
         return str == null ? null : str.replace(" ", "%20");
     }
-
+    
     public static String format(byte field, WarcCaptureRecord record) {
+        return format(field,record,false);
+    }
+      
+    public static String format(byte field, WarcCaptureRecord record, boolean digestUnchanged) {
         try {
             switch (field) {
                 case CHECKSUM:
-                    return record.payloadDigest().map(WarcDigest::base32).orElse("-");
+                    if (digestUnchanged) {
+                        return record.payloadDigestUnchanged().get();        
+                    }
+                    else {
+                      return record.payloadDigest().map(WarcDigest::base32).orElse("-");
+                    }
                 case DATE:
                     return DATE_FORMAT.format(record.date());
                 case MIME_TYPE:

--- a/src/org/netpreserve/jwarc/cdx/CdxFormat.java
+++ b/src/org/netpreserve/jwarc/cdx/CdxFormat.java
@@ -18,7 +18,8 @@ public class CdxFormat {
 
     private final byte[] fieldNames;
     private final byte[] fieldIndices;
-
+    private boolean digestUnchanged=false;
+    
     public CdxFormat(String legend) {
         String[] fields = legend.replaceFirst("^ ?CDX ", "").split(" ");
         fieldNames = new byte[fields.length];
@@ -82,14 +83,18 @@ public class CdxFormat {
                     if (urlkey != null) {
                         value = urlkey;
                     } else {
-                        value = CdxFields.format(fieldName, record);
+                        value = CdxFields.format(fieldName, record,digestUnchanged);
                     }
                     break;
                 default:
-                    value = CdxFields.format(fieldName, record);
+                    value = CdxFields.format(fieldName, record,digestUnchanged);
             }
             builder.append(value);
         }
         return builder.toString();
+    }
+    
+    public void setDigestUnchanged(boolean digestUnchanged) {
+        this.digestUnchanged=digestUnchanged;
     }
 }

--- a/src/org/netpreserve/jwarc/tools/CdxTool.java
+++ b/src/org/netpreserve/jwarc/tools/CdxTool.java
@@ -57,6 +57,10 @@ public class CdxTool {
                     case "--post-append":
                         postAppend = true;
                         break;
+                    case "-d":
+                    case "--digest-unchanged":
+                        cdxFormat.setDigestUnchanged(true);
+                        break;                                                                              
                     default:
                         System.err.println("Unrecognized option: " + args[i]);
                         System.err.println("Usage: jwarc cdx [--format LEGEND] warc-files...");

--- a/test/org/netpreserve/jwarc/cdx/CdxFormatTest.java
+++ b/test/org/netpreserve/jwarc/cdx/CdxFormatTest.java
@@ -3,11 +3,9 @@ package org.netpreserve.jwarc.cdx;
 import org.junit.Test;
 import org.netpreserve.jwarc.HttpResponse;
 import org.netpreserve.jwarc.MediaType;
-import org.netpreserve.jwarc.WarcDigest;
 import org.netpreserve.jwarc.WarcResponse;
 
 import java.io.IOException;
-import java.security.MessageDigest;
 import java.time.Instant;
 
 import static org.junit.Assert.*;
@@ -31,6 +29,7 @@ public class CdxFormatTest {
     public void testDigestUnchanged() throws Exception {
         CdxFormat cdxFormat = CdxFormat.CDX11;
         cdxFormat.setDigestUnchanged(true); //We want the digest as is.
+        String payloadDigest="sha256:b04af472c47a8b1b5059b3404caac0e1bfb5a3c07b329be66f65cfab5ee8d3f3";    
                 
         HttpResponse httpResponse = new HttpResponse.Builder(404, "Not Found")
                 .body(MediaType.HTML, new byte[0])
@@ -38,9 +37,9 @@ public class CdxFormatTest {
         WarcResponse response = new WarcResponse.Builder("http://example.org/")
                 .date(Instant.parse("2022-03-02T21:44:34Z"))                                                               
                 .body(httpResponse)
-                .addHeader("WARC-Payload-Digest", "sha256:b04af472c47a8b1b5059b3404caac0e1bfb5a3c07b329be66f65cfab5ee8d3f3") 
+                .addHeader("WARC-Payload-Digest", payloadDigest) 
                 .build();
-        assertEquals("org,example)/ 20220302214434 http://example.org/ text/html 404 sha256:b04af472c47a8b1b5059b3404caac0e1bfb5a3c07b329be66f65cfab5ee8d3f3 - - 456 123 example.warc.gz",                      
+        assertEquals("org,example)/ 20220302214434 http://example.org/ text/html 404 "+payloadDigest+" - - 456 123 example.warc.gz",                      
                 cdxFormat.format(response, "example.warc.gz", 123, 456));
     }
 

--- a/test/org/netpreserve/jwarc/cdx/CdxFormatTest.java
+++ b/test/org/netpreserve/jwarc/cdx/CdxFormatTest.java
@@ -3,9 +3,11 @@ package org.netpreserve.jwarc.cdx;
 import org.junit.Test;
 import org.netpreserve.jwarc.HttpResponse;
 import org.netpreserve.jwarc.MediaType;
+import org.netpreserve.jwarc.WarcDigest;
 import org.netpreserve.jwarc.WarcResponse;
 
 import java.io.IOException;
+import java.security.MessageDigest;
 import java.time.Instant;
 
 import static org.junit.Assert.*;
@@ -24,4 +26,24 @@ public class CdxFormatTest {
         assertEquals("org,example)/ 20220302214434 http://example.org/ text/html 404 AQLNJ7DOPHK477BWWC726H7Y5XBPBNF7 - - 456 123 example.warc.gz",
                 CdxFormat.CDX11.format(response, "example.warc.gz", 123, 456));
     }
+
+    @Test
+    public void testDigestUnchanged() throws Exception {
+        CdxFormat cdxFormat = CdxFormat.CDX11;
+        cdxFormat.setDigestUnchanged(true); //We want the digest as is.
+                
+        HttpResponse httpResponse = new HttpResponse.Builder(404, "Not Found")
+                .body(MediaType.HTML, new byte[0])
+                .build();
+        WarcResponse response = new WarcResponse.Builder("http://example.org/")
+                .date(Instant.parse("2022-03-02T21:44:34Z"))                                                               
+                .body(httpResponse)
+                .addHeader("WARC-Payload-Digest", "sha256:b04af472c47a8b1b5059b3404caac0e1bfb5a3c07b329be66f65cfab5ee8d3f3") 
+                .build();
+        assertEquals("org,example)/ 20220302214434 http://example.org/ text/html 404 sha256:b04af472c47a8b1b5059b3404caac0e1bfb5a3c07b329be66f65cfab5ee8d3f3 - - 456 123 example.warc.gz",                      
+                cdxFormat.format(response, "example.warc.gz", 123, 456));
+    }
+
+
+
 }


### PR DESCRIPTION
My attempt to add support for CDX indexing using the payload digest from the WARC-header without base64 encoding it.

To enable it, I added two additional arguments to the  CDX indexer

**case "-d":
case "--digest-unchanged":**

There is a unittest as well.