### PR TITLE
GitHub 71 include revisits

### DIFF
--- a/src/org/netpreserve/jwarc/WarcRevisit.java
+++ b/src/org/netpreserve/jwarc/WarcRevisit.java
@@ -13,6 +13,8 @@ import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.netpreserve.jwarc.WarcResponse.Builder;
+
 /**
  * A WARC record describing a subsequent visitation of content previously archived. Typically used to indicate the
  * content had not changed and therefore a duplicate copy of it was not recorded.
@@ -128,11 +130,20 @@ public class WarcRevisit extends WarcCaptureRecord {
             setHeader("WARC-Profile", profile.toString());
         }
 
+        public Builder body(HttpResponse httpResponse) throws IOException { //revisit still have HTTP header, but no payload
+            return body(MediaType.HTTP_RESPONSE, httpResponse);
+        }
+        
         @Override
         public WarcRevisit build() {
             return build(WarcRevisit::new);
         }
 
+        public Builder(String targetURI) {
+            super("revisit");
+            setHeader("WARC-Target-URI", targetURI);
+        }
+        
         public Builder refersTo(URI recordId) {
             return setHeader("WARC-Refers-To", WarcRecord.formatId(recordId));
         }

--- a/test/org/netpreserve/jwarc/cdx/CdxFormatTest.java
+++ b/test/org/netpreserve/jwarc/cdx/CdxFormatTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import org.netpreserve.jwarc.HttpResponse;
 import org.netpreserve.jwarc.MediaType;
 import org.netpreserve.jwarc.WarcResponse;
+import org.netpreserve.jwarc.WarcRevisit;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -44,6 +45,26 @@ public class CdxFormatTest {
                 cdxFormat.format(response, "example.warc.gz", 123, 456));
     }
 
-
+    
+    @Test
+    public void testRevisit() throws Exception {
+        CdxFormat cdxFormat = new CdxFormat.Builder()
+                .digestUnchanged() // We want the digest as is.
+                .revisistsIncluded() 
+                .build();
+        String payloadDigest="sha256:b04af472c47a8b1b5059b3404caac0e1bfb5a3c07b329be66f65cfab5ee8d3f3";
+                
+        HttpResponse httpResponse = new HttpResponse.Builder(404, "Not Found")
+                .body(MediaType.HTML, new byte[0])
+                .build();
+        WarcRevisit revisit = new WarcRevisit.Builder("http://example.org/")
+                .date(Instant.parse("2022-03-02T21:44:34Z"))                
+                .body(httpResponse)
+                .addHeader("WARC-Payload-Digest", payloadDigest)
+                .addHeader("WARC-Type", "revisit")
+                .build();
+        assertEquals("org,example)/ 20220302214434 http://example.org/ warc/revisit 404 "+payloadDigest+" - - 456 123 example.warc.gz",                      
+                cdxFormat.format(revisit, "example.warc.gz", 123, 456));
+    }
 
 }


### PR DESCRIPTION
    Add support for revisit lines in CDX-indexer
    
    New option -r or --revisits-included to include revisit for the
    CDX-tool.
    
    The mime-type will be set to 'warc/revisit' to support PyWb.
    (calendar entry as revisit)
    
    The PR closes https://github.com/iipc/jwarc/issues/71
