### PR TITLE
Cdxtool output refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
 .idea
 target
 *.iml
-/.project
-/.classpath
-/.gitignore
-/.settings/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .idea
 target
 *.iml
+/.project
+/.classpath
+/.gitignore
+/.settings/

--- a/src/org/netpreserve/jwarc/cdx/CdxProcessor.java
+++ b/src/org/netpreserve/jwarc/cdx/CdxProcessor.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2021 National Library of Australia
+ */
+
 package org.netpreserve.jwarc.cdx;
 
 import java.io.IOException;

--- a/src/org/netpreserve/jwarc/cdx/CdxProcessor.java
+++ b/src/org/netpreserve/jwarc/cdx/CdxProcessor.java
@@ -1,0 +1,88 @@
+package org.netpreserve.jwarc.cdx;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.netpreserve.jwarc.HttpRequest;
+import org.netpreserve.jwarc.ParsingException;
+import org.netpreserve.jwarc.URIs;
+import org.netpreserve.jwarc.WarcCaptureRecord;
+import org.netpreserve.jwarc.WarcReader;
+import org.netpreserve.jwarc.WarcRecord;
+import org.netpreserve.jwarc.WarcRequest;
+import org.netpreserve.jwarc.WarcResource;
+import org.netpreserve.jwarc.WarcResponse;
+import org.netpreserve.jwarc.WarcRevisit;
+
+public class CdxProcessor {
+
+    
+    public static void process(boolean printHeader, boolean postAppend, List<Path> files,                 
+            CdxFormat.Builder cdxFormatBuilder, PrintStream printStream) throws IOException {       
+            CdxFormat cdxFormat = cdxFormatBuilder.build();
+                
+        if (printHeader) {
+            printStream.println(" CDX " + cdxFormat.legend());
+        }
+
+        for (Path file: files) {
+            try (WarcReader reader = new WarcReader(file)) {
+                reader.onWarning(System.err::println);
+                WarcRecord record = reader.next().orElse(null);
+
+                while (record != null) {
+                    try {
+                        if ( (record instanceof WarcResponse || record instanceof WarcResource) && 
+                             ((WarcCaptureRecord) record).payload().isPresent()
+                             || (record instanceof WarcRevisit && cdxFormatBuilder.isRevisitsIncluded()) ) {                                 
+                            long position = reader.position();
+                            WarcCaptureRecord capture = (WarcCaptureRecord) record;
+                            URI id = record.version().getProtocol().equals("ARC") ? null : record.id();
+
+                            // advance to the next record so we can calculate the length
+                            record = reader.next().orElse(null);
+                            long length = reader.position() - position;
+
+                            String urlKey = null;
+                            if (postAppend) {
+                                // check for a corresponding request record
+                                while (urlKey == null && record instanceof WarcCaptureRecord
+                                        && ((WarcCaptureRecord) record).concurrentTo().contains(id)) {
+                                    if (record instanceof WarcRequest) {
+                                        HttpRequest httpRequest = ((WarcRequest) record).http();
+                                        String encodedRequest = CdxRequestEncoder.encode(httpRequest);
+                                        if (encodedRequest != null) {
+                                            String rawUrlKey = capture.target() +
+                                                    (capture.target().contains("?") ? '&' : '?')
+                                                    + encodedRequest;
+                                            urlKey = URIs.toNormalizedSurt(rawUrlKey);
+                                        }
+                                    }
+
+                                    record = reader.next().orElse(null);
+                                }
+                            }
+                             
+                            String line=cdxFormat.format(capture, file, position, length, urlKey);
+                            printStream.println(line);                            
+
+                        } else {
+                            record = reader.next().orElse(null);
+                        }
+                    } catch (ParsingException e) {
+                        System.err.println("ParsingException at record " + reader.position() + ": " + e.getMessage());
+                        record = reader.next().orElse(null);
+                    }
+               
+                    if (record instanceof WarcRevisit) {
+                        ((WarcRevisit)record).http(); // ensure http header is parsed before advancing. Revisits has no payload, but we still need the HTTP status.
+                   }
+                
+                }
+            }
+        }
+    }   
+}

--- a/src/org/netpreserve/jwarc/tools/CdxTool.java
+++ b/src/org/netpreserve/jwarc/tools/CdxTool.java
@@ -5,12 +5,12 @@
 
 package org.netpreserve.jwarc.tools;
 
-import org.netpreserve.jwarc.*;
+
 import org.netpreserve.jwarc.cdx.CdxFormat;
-import org.netpreserve.jwarc.cdx.CdxRequestEncoder;
+import org.netpreserve.jwarc.cdx.CdxProcessor;
+
 
 import java.io.IOException;
-import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -25,119 +25,60 @@ public class CdxTool {
         for (int i = 0; i < args.length; i++) {
             if (args[i].startsWith("-")) {
                 switch (args[i]) {
-                    case "-f":
-                    case "--format":
-                        String format = args[++i];
-                        switch (format) {
-                            case "CDX9":
-                                cdxFormatBuilder.legend(CdxFormat.CDX9_LEGEND);
-                                break;
-                            case "CDX10":
-                                cdxFormatBuilder.legend(CdxFormat.CDX10_LEGEND);
-                                break;
-                            case "CDX11":
-                                cdxFormatBuilder.legend(CdxFormat.CDX11_LEGEND);
-                                break;
-                            default:
-                                cdxFormatBuilder.legend(format);
-                                break;
-                        }
+                case "-f":
+                case "--format":
+                    String format = args[++i];
+                    switch (format) {
+                    case "CDX9":
+                        cdxFormatBuilder.legend(CdxFormat.CDX9_LEGEND);
                         break;
-                    case "-h":
-                    case "--help":
-                        System.out.println("Usage: jwarc cdx [--format LEGEND] warc-files...");
-                        System.out.println();
-                        System.out.println("  -f, --format LEGEND  CDX format may be CDX9, CDX11 or a custom legend");
-                        System.out.println("      --no-header      Don't print the CDX header line");
-                        return;
-                    case "--no-header":
-                        printHeader = false;
+                    case "CDX10":
+                        cdxFormatBuilder.legend(CdxFormat.CDX10_LEGEND);
                         break;
-                    case "-p":
-                    case "--post-append":
-                        postAppend = true;
+                    case "CDX11":
+                        cdxFormatBuilder.legend(CdxFormat.CDX11_LEGEND);
                         break;
-                    case "-d":
-                    case "--digest-unchanged":
-                        cdxFormatBuilder.digestUnchanged();
-                        break;
-                    case "-r":
-                    case "--revisits-included":
-                        cdxFormatBuilder.revisistsIncluded();
-                        break;
-                    case "-w":
-                    case "--warc-full-path":
-                        cdxFormatBuilder.fullFilePath();
-                        break;                         
                     default:
-                        System.err.println("Unrecognized option: " + args[i]);
-                        System.err.println("Usage: jwarc cdx [--format LEGEND] warc-files...");
-                        System.exit(1);
-                        return;
+                        cdxFormatBuilder.legend(format);
+                        break;
+                    }
+                    break;
+                case "-h":
+                case "--help":
+                    System.out.println("Usage: jwarc cdx [--format LEGEND] warc-files...");
+                    System.out.println();
+                    System.out.println("  -f, --format LEGEND  CDX format may be CDX9, CDX11 or a custom legend");
+                    System.out.println("      --no-header      Don't print the CDX header line");
+                    return;
+                case "--no-header":
+                    printHeader = false;
+                    break;
+                case "-p":
+                case "--post-append":
+                    postAppend = true;
+                    break;
+                case "-d":
+                case "--digest-unchanged":
+                    cdxFormatBuilder.digestUnchanged();
+                    break;
+                case "-r":
+                case "--revisits-included":
+                    cdxFormatBuilder.revisistsIncluded();
+                    break;
+                case "-w":
+                case "--warc-full-path":
+                    cdxFormatBuilder.fullFilePath();
+                    break;                         
+                default:
+                    System.err.println("Unrecognized option: " + args[i]);
+                    System.err.println("Usage: jwarc cdx [--format LEGEND] warc-files...");
+                    System.exit(1);
+                    return;
                 }
             } else {
                 files.add(Paths.get(args[i]));
             }
         }
-
-        CdxFormat cdxFormat = cdxFormatBuilder.build();
-        if (printHeader) {
-            System.out.println(" CDX " + cdxFormat.legend());
-        }
-
-        for (Path file: files) {
-            try (WarcReader reader = new WarcReader(file)) {
-                reader.onWarning(System.err::println);
-                WarcRecord record = reader.next().orElse(null);
-                
-                while (record != null) {
-                    try {
-                        if ( (record instanceof WarcResponse || record instanceof WarcResource) && 
-                             ((WarcCaptureRecord) record).payload().isPresent()
-                             || (record instanceof WarcRevisit && cdxFormatBuilder.isRevisitsIncluded()) ) {                                 
-                            long position = reader.position();
-                            WarcCaptureRecord capture = (WarcCaptureRecord) record;
-                            URI id = record.version().getProtocol().equals("ARC") ? null : record.id();
-
-                            // advance to the next record so we can calculate the length
-                            record = reader.next().orElse(null);
-                            long length = reader.position() - position;
-
-                            String urlKey = null;
-                            if (postAppend) {
-                                // check for a corresponding request record
-                                while (urlKey == null && record instanceof WarcCaptureRecord
-                                        && ((WarcCaptureRecord) record).concurrentTo().contains(id)) {
-                                    if (record instanceof WarcRequest) {
-                                        HttpRequest httpRequest = ((WarcRequest) record).http();
-                                        String encodedRequest = CdxRequestEncoder.encode(httpRequest);
-                                        if (encodedRequest != null) {
-                                            String rawUrlKey = capture.target() +
-                                                    (capture.target().contains("?") ? '&' : '?')
-                                                    + encodedRequest;
-                                            urlKey = URIs.toNormalizedSurt(rawUrlKey);
-                                        }
-                                    }
-
-                                    record = reader.next().orElse(null);
-                                }
-                            }
-
-                            System.out.println(cdxFormat.format(capture, file, position, length, urlKey));
-                        } else {
-                            record = reader.next().orElse(null);
-                        }
-                    } catch (ParsingException e) {
-                        System.err.println("ParsingException at record " + reader.position() + ": " + e.getMessage());
-                        record = reader.next().orElse(null);
-                    }
-               
-                    if (record instanceof WarcRevisit) {
-                        ((WarcRevisit)record).http(); // ensure http header is parsed before advancing. Revisits has no payload, but we still need the HTTP status.
-                   }
-                
-                }
-            }
-        }
+        CdxProcessor.process(printHeader, postAppend, files, cdxFormatBuilder,System.out); //Output to System.out
     }
 }


### PR DESCRIPTION
Refactoring the WARC-record iteration and output generation to a new class. The class can be given a PrintWriter. The CDX-tool will now  call the class with System.out as PrintWriter, so everything is working as before.

The refactoring will make it possible for java code make the same cdx-output as was printed to System.out before with the CDX-tool.

