### PR TITLE
Add support for Content-Encoding: zstd

### DIFF
--- a/src/org/netpreserve/jwarc/DecodedBody.java
+++ b/src/org/netpreserve/jwarc/DecodedBody.java
@@ -18,7 +18,8 @@ public class DecodedBody extends MessageBody {
     public static enum Encoding {
         DEFLATE,
         GZIP,
-        BROTLI
+        BROTLI,
+        ZSTD
     }
 
     private final ReadableByteChannel channel;
@@ -39,6 +40,15 @@ public class DecodedBody extends MessageBody {
                 this.channel = BrotliUtils.brotliChannel(channel);
             } catch (NoClassDefFoundError e) {
                 throw new IOException("Brotli decoder not found, please install org.brotli:dec", e);
+            }
+            break;
+        case ZSTD:
+            try {
+                ByteBuffer buf = ByteBuffer.allocate(8192);
+                buf.flip();
+                this.channel = new ZstdDecompressingChannel(channel, buf);
+            } catch (NoClassDefFoundError e) {
+                throw new IOException("ZStandard decoder not found, please install com.github.luben:zstd-jni", e);
             }
             break;
         default:

--- a/src/org/netpreserve/jwarc/HttpMessage.java
+++ b/src/org/netpreserve/jwarc/HttpMessage.java
@@ -46,6 +46,8 @@ public abstract class HttpMessage extends Message {
             return DecodedBody.create(payload, DecodedBody.Encoding.BROTLI);
         } else if (contentEncodings.get(0).equalsIgnoreCase("deflate")) {
             return DecodedBody.create(payload, DecodedBody.Encoding.DEFLATE);
+        } else if (contentEncodings.get(0).equalsIgnoreCase("zstd")) {
+            return DecodedBody.create(payload, DecodedBody.Encoding.ZSTD);
         } else {
             throw new IOException("Content-Encoding not supported: " + contentEncodings.get(0));
         }


### PR DESCRIPTION
Support [Content-Encoding](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Encoding#directives) `zstd`, based on the existing `ZstdDecompressingChannel`.

Tested
- on [zstd-content-encoding-test-5.warc.gz](https://github.com/user-attachments/files/24260495/zstd-content-encoding-test-5.warc.gz)
- per `mvn -q exec:java -Dexec.mainClass=org.netpreserve.jwarc.tools.WarcTool -Dexec.args="extract --payload zstd-content-encoding-test-5.warc.gz 2339"`