### PR TITLE
Drop Java 8 support: raise baseline to Java 11 (resolves #102)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,8 +94,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
     </properties>
 
     <developers>
@@ -182,7 +182,7 @@
                 <jdk>[9,)</jdk>
             </activation>
             <properties>
-                <maven.compiler.release>8</maven.compiler.release>
+                <maven.compiler.release>11</maven.compiler.release>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
Resolves #102.

Raises the baseline from Java 8 to **Java 11**, as proposed in the issue:

- `pom.xml`: `maven.compiler.source`/`target` `1.8` → `11`, and the `[9,)`-activated profile's `maven.compiler.release` `8` → `11`. That profile was pinning JDK-9+ builds back to Java-8 bytecode, so CI (already on JDK 11) was still emitting v52 — flipping it is what actually drops the Java-8 target.

This unblocks the Java 11 APIs noted in the issue — `InputStream.transferTo()`, direct `ByteBuffer` inflation (#45), and `java.net.http.HttpClient`.

## Verification
Ran the repo's own CI command on Temurin 11:
- `mvn -B package` → **BUILD SUCCESS**, **127 tests, 0 failures, 3 skipped** — identical to the Java-8 baseline.

No source changes; CI already uses `java-version: '11'`, so no workflow change is needed.

🤖 Migrated with the [bump-java-version](https://github.com/vasiliy-mikhailov/bump-java-version-skill) skill.
