### PR TITLE
Add Dependabot configuration for GitHub workflow actions.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: weekly


### PR DESCRIPTION
GitHub's Dependabot can update workflow actions, see [Keeping your actions up to date with Dependabot](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/keeping-your-actions-up-to-date-with-dependabot).

Regularly updating the actions is important to reduce the risk of security issues when running workflows. For example, see the history of [actions/checkout](https://github.com/actions/checkout#checkout-v7), v6 and v7. This PR configures weekly updates.